### PR TITLE
The correct keyword argument is `install_requires` not `requires`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ cleaning parameter and query strings, and a little more sanitization.
 		'Environment :: Web Environment',
 		'Intended Audience :: Developers',
 		'Topic :: Internet :: WWW/HTTP'],
-	requires = ['publicsuffix']
+	install_requires = ['publicsuffix']
 )


### PR DESCRIPTION
I noticed that `pip install url` did not actually install `publicsuffix` as expected.

This makes it work automatically.
