### PR TITLE
install_requires need a version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,6 @@ cleaning parameter and query strings, and a little more sanitization.
 		'Environment :: Web Environment',
 		'Intended Audience :: Developers',
 		'Topic :: Internet :: WWW/HTTP'],
-	install_requires = ['publicsuffix']
+	install_requires = [
+		'publicsuffix >= 1.0.5']
 )


### PR DESCRIPTION
@dlecocq

Strangely `publicsuffix` is install if I do a `pip install -e /path/to/url-py` but it neglects to install `publicsuffix` if I install from pypi.  Then when I do `import url` I get an import error for publicsuffix:

```
IPython 2.0.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: import url
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-1-a53e76b52a78> in <module>()
----> 1 import url

/Users/peterconerly/.virtualenvs/derp/lib/python2.7/site-packages/url.py in <module>()
     34 
     35 # For publicsuffix utilities
---> 36 from publicsuffix import PublicSuffixList
     37 psl = PublicSuffixList()
     38 

ImportError: No module named publicsuffix
```

I'm not 100% that this PR will work, given that I can't publish to pypi for ya.
