### PR TITLE
Bumping version: avoid conflict with Pypi 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ except ImportError:
 
 setup(
 	name             = 'url',
-	version          = '0.1.1',
+	version          = '0.1.2',
 	description      = 'URL Parsing',
 	long_description = '''
 Some helper functions for parsing URLs, sanitizing them, normalizing them.


### PR DESCRIPTION
The Pypi version does not match this anymore. 
Could I suggest to tag Pypi releases too?
Thanks !
