### PR TITLE
Fix an overlooked bug in strict mode.

### DIFF
--- a/url.py
+++ b/url.py
@@ -69,7 +69,7 @@ class URL(object):
     UNRESERVED = ALPHA + DIGIT + "-._~"
     PCHAR = UNRESERVED + SUB_DELIMS + ":@"
     PATH = PCHAR + "/"
-    QUERY = PCHAR + "?"
+    QUERY = PCHAR + "?/"
     FRAGMENT = PCHAR + "?"
     USERINFO = UNRESERVED + SUB_DELIMS + ":"
 


### PR DESCRIPTION
OK, in contrast to the last one, this pull request is REALLY simple. The old code defines:

GEN_DELIMS = ":/?#[]@"
SUB_DELIMS = "!$&'()*+,;="
ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
DIGIT = "0123456789"
UNRESERVED = ALPHA + DIGIT + "-._~"
RESERVED = GEN_DELIMS + SUB_DELIMS
PCHAR = UNRESERVED + SUB_DELIMS + ":@/"  # Slash legal in path, so include it
QUERY = PCHAR + "?"  # Slash already included above.
USERINFO = UNRESERVED + SUB_DELIMS + ":"

But the new code went:

SUB_DELIMS = "!$&'()*+,;="
ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
DIGIT = "0123456789"
UNRESERVED = ALPHA + DIGIT + "-._~"
PCHAR = UNRESERVED + SUB_DELIMS + ":@"
PATH = PCHAR + "/"
QUERY = PCHAR + "?"
FRAGMENT = PCHAR + "?"
USERINFO = UNRESERVED + SUB_DELIMS + ":"

This resulted in the slash character being encoded in the query when it doesn't need to be and wasn't before (because it's now missing thanks to it being removed from PCHAR. Fix is really simple, of course, and is the subject of this pull request.

That's all.
