### PR TITLE
Strict-Mode Unencoding Entities

### DIFF
--- a/test.py
+++ b/test.py
@@ -114,7 +114,9 @@ class Test(unittest.TestCase):
             (u'http://José:no way@foo.com'  , 'http://Jos%C3%A9:no%20way@foo.com'),
             ('http://oops!:don%27t@foo.com' , 'http://oops!:don%27t@foo.com'     ),
             (u'española,nm%2cusa.html?gunk=junk+glunk&foo=bar baz',
-                'espa%C3%B1ola,nm%2Cusa.html?gunk=junk+glunk&foo=bar%20baz')
+                'espa%C3%B1ola,nm%2Cusa.html?gunk=junk+glunk&foo=bar%20baz'),
+            ('http://foo.com/bar\nbaz.html\n', 'http://foo.com/bar%0Abaz.html%0A'),
+            ('http://foo.com/bar.jsp?param=\n/value%2F', 'http://foo.com/bar.jsp?param=%0A/value%2F'),
         ]
 
         base = 'http://testing.com/'

--- a/test.py
+++ b/test.py
@@ -109,6 +109,7 @@ class Test(unittest.TestCase):
         '''Test strict mode escaping'''
         examples = [
             ('danny%27s pub'                , 'danny%27s%20pub'                  ),
+            ('this%5Fand%5Fthat'            , 'this_and_that'                    ),
             ('http://user:pass@foo.com'     , 'http://user:pass@foo.com'         ),
             (u'http://José:no way@foo.com'  , 'http://Jos%C3%A9:no%20way@foo.com'),
             ('http://oops!:don%27t@foo.com' , 'http://oops!:don%27t@foo.com'     ),

--- a/url.py
+++ b/url.py
@@ -63,17 +63,19 @@ class URL(object):
     '''
 
     # Via http://www.ietf.org/rfc/rfc3986.txt
+    GEN_DELIMS = ":/?#[]@"
     SUB_DELIMS = "!$&'()*+,;="
     ALPHA = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
     DIGIT = "0123456789"
     UNRESERVED = ALPHA + DIGIT + "-._~"
+    RESERVED = GEN_DELIMS + SUB_DELIMS
     PCHAR = UNRESERVED + SUB_DELIMS + ":@"
     PATH = PCHAR + "/"
     QUERY = PCHAR + "?"
     FRAGMENT = PCHAR + "?"
     USERINFO = UNRESERVED + SUB_DELIMS + ":"
 
-    PERCENT_ESCAPING_RE = re.compile('(%[a-fA-F0-9]{2}|.)')
+    PERCENT_ESCAPING_RE = re.compile('(%([a-fA-F0-9]{2})|.)')
 
     @classmethod
     def parse(cls, url, encoding):
@@ -229,6 +231,10 @@ class URL(object):
                 else:
                     return '%%%02X' % ord(string)
             else:
+                # Replace any escaped entities with their equivalent if needed.
+                character = chr(int(match.group(2), 16))
+                if (character in safe) and not (character in URL.RESERVED):
+                    return character
                 return string.upper()
 
         return URL.PERCENT_ESCAPING_RE.sub(replacement, raw)

--- a/url.py
+++ b/url.py
@@ -71,11 +71,11 @@ class URL(object):
     RESERVED = GEN_DELIMS + SUB_DELIMS
     PCHAR = UNRESERVED + SUB_DELIMS + ":@"
     PATH = PCHAR + "/"
-    QUERY = PCHAR + "?"
-    FRAGMENT = PCHAR + "?"
+    QUERY = PCHAR + "/?"
+    FRAGMENT = PCHAR + "/?"
     USERINFO = UNRESERVED + SUB_DELIMS + ":"
 
-    PERCENT_ESCAPING_RE = re.compile('(%([a-fA-F0-9]{2})|.)')
+    PERCENT_ESCAPING_RE = re.compile('(%([a-fA-F0-9]{2})|.)', re.S)
 
     @classmethod
     def parse(cls, url, encoding):


### PR DESCRIPTION
This is aimed at unencoding entities that may be safely unencoded when used with `escape` in strict mode.