### PR TITLE
Switch to use an updated fork of publicsuffix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ cleaning parameter and query strings, and a little more sanitization.
 	install_requires = [
 		'coverage',
 		'nose',
-		'publicsuffix'
+		'publicsuffix2'
 	]
 )


### PR DESCRIPTION
Use  publicsuffix2 with updated data and the same API as publicsuffix
https://github.com/pombredanne/python-publicsuffix2
and https://pypi.python.org/pypi/publicsuffix2
This would fix #29 and also addresses a bug in wheel https://bitbucket.org/pypa/wheel/issue/120/