### PR TITLE
Explicitly include C++ files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include url/url.cpp
+include url/url-cpp/src/*
+include url/url-cpp/include/*


### PR DESCRIPTION
When releasing, we should explicitly include the `.cpp` and `.h` files. Looking at the `MANIFEST` in preparing for a PyPI release, I noticed they were conspicuously absent.

@b4hand @lindseyreno 