### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: trusty
 language: python
 python:
   - 2.7
+  - 3.3
+  - 3.4
+  - 3.5
 # before_install: scripts/travis/before_install.sh
 install: pip install -r requirements.txt
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 dist: trusty
 language: python
 python:
-  - 2.6
   - 2.7
 # before_install: scripts/travis/before_install.sh
 install: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ nose==1.3.7
 nose-timer==0.6.0
 python-termstyle==0.1.10
 rednose==1.2.1
+six==1.10.0
 termcolor==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,9 @@ cleaning parameter and query strings, and a little more sanitization.
     package_data     = {
         'url': ['psl/*']
     },
+    install_requires = [
+        'six'
+    ],
     tests_require    = [
         'coverage',
         'nose'

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ ext_modules = [
 
 setup(
     name             = 'url',
-    version          = '0.3.0rc2',
+    version          = '0.3.0',
     description      = 'URL Parsing',
     long_description = '''
 Some helper functions for parsing URLs, sanitizing them, normalizing them.

--- a/url/__init__.py
+++ b/url/__init__.py
@@ -23,8 +23,15 @@
 
 '''This is a module for dealing with urls. In particular, sanitizing them.'''
 
+import sys
 
-from .url import URL, set_psl
+from six import text_type
+if text_type == str:
+    from .url import UnicodeURL as URL
+else:
+    from .url import StringURL as URL
+
+from .url import set_psl
 
 def parse(url, encoding='utf-8'):
     '''Parse the provided url string and return an URL object'''

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -508,32 +508,45 @@ static const char *__pyx_f[] = {
 };
 
 /*--- Type declarations ---*/
-struct __pyx_obj_3url_3url_URL;
+struct __pyx_obj_3url_3url_StringURL;
+struct __pyx_obj_3url_3url_UnicodeURL;
 struct __pyx_obj_3url_3url___pyx_scope_struct__deparam;
 struct __pyx_obj_3url_3url___pyx_scope_struct_1_genexpr;
 struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params;
 struct __pyx_obj_3url_3url___pyx_scope_struct_3_genexpr;
 struct __pyx_obj_3url_3url___pyx_scope_struct_4_genexpr;
 
-/* "url/url.pyx":23
+/* "url/url.pyx":29
+ *     return obj
  * 
- * 
- * cdef class URL:             # <<<<<<<<<<<<<<
- *     '''Wrapper around url-cpp.'''
+ * cdef class StringURL:             # <<<<<<<<<<<<<<
+ *     '''Wrapper around url-cpp, which deals in strings.'''
  * 
  */
-struct __pyx_obj_3url_3url_URL {
+struct __pyx_obj_3url_3url_StringURL {
   PyObject_HEAD
   Url::Url *ptr;
 };
 
 
-/* "url/url.pyx":123
+/* "url/url.pyx":255
+ * 
+ * 
+ * cdef class UnicodeURL(StringURL):             # <<<<<<<<<<<<<<
+ *     '''A version of the URL class that deals in Unicode.'''
+ *     property scheme:
+ */
+struct __pyx_obj_3url_3url_UnicodeURL {
+  struct __pyx_obj_3url_3url_StringURL __pyx_base;
+};
+
+
+/* "url/url.pyx":135
  *         return self
  * 
  *     def deparam(self, params):             # <<<<<<<<<<<<<<
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
  */
 struct __pyx_obj_3url_3url___pyx_scope_struct__deparam {
   PyObject_HEAD
@@ -541,10 +554,10 @@ struct __pyx_obj_3url_3url___pyx_scope_struct__deparam {
 };
 
 
-/* "url/url.pyx":125
+/* "url/url.pyx":137
  *     def deparam(self, params):
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)             # <<<<<<<<<<<<<<
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)             # <<<<<<<<<<<<<<
  *         self.ptr.deparam(lowered)
  *         return self
  */
@@ -558,22 +571,22 @@ struct __pyx_obj_3url_3url___pyx_scope_struct_1_genexpr {
 };
 
 
-/* "url/url.pyx":129
+/* "url/url.pyx":141
  *         return self
  * 
  *     def filter_params(self, function):             # <<<<<<<<<<<<<<
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):
  */
 struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params {
   PyObject_HEAD
   PyObject *__pyx_v_function;
   PyObject *__pyx_v_keep;
-  struct __pyx_obj_3url_3url_URL *__pyx_v_self;
+  struct __pyx_obj_3url_3url_StringURL *__pyx_v_self;
 };
 
 
-/* "url/url.pyx":134
+/* "url/url.pyx":146
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))             # <<<<<<<<<<<<<<
@@ -590,7 +603,7 @@ struct __pyx_obj_3url_3url___pyx_scope_struct_3_genexpr {
 };
 
 
-/* "url/url.pyx":135
+/* "url/url.pyx":147
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))             # <<<<<<<<<<<<<<
@@ -935,6 +948,9 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallMethO(PyObject *func, PyObject
 /* PyObjectCallOneArg.proto */
 static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObject *arg);
 
+/* GetModuleGlobalName.proto */
+static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name);
+
 /* PyThreadStateGet.proto */
 #if CYTHON_COMPILING_IN_CPYTHON
 #define __Pyx_PyThreadState_declare  PyThreadState *__pyx_tstate;
@@ -1114,8 +1130,8 @@ static CYTHON_INLINE PyObject* __Pyx_decode_cpp_string(
 /* Import.proto */
 static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level);
 
-/* GetModuleGlobalName.proto */
-static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name);
+/* ImportFrom.proto */
+static PyObject* __Pyx_ImportFrom(PyObject* module, PyObject* name);
 
 /* CodeObjectCache.proto */
 typedef struct {
@@ -1264,13 +1280,15 @@ static int __Pyx_InitStrings(__Pyx_StringTabEntry *t);
 /* Module declarations from 'libcpp' */
 
 /* Module declarations from 'url.url' */
-static PyTypeObject *__pyx_ptype_3url_3url_URL = 0;
+static PyTypeObject *__pyx_ptype_3url_3url_StringURL = 0;
+static PyTypeObject *__pyx_ptype_3url_3url_UnicodeURL = 0;
 static PyTypeObject *__pyx_ptype_3url_3url___pyx_scope_struct__deparam = 0;
 static PyTypeObject *__pyx_ptype_3url_3url___pyx_scope_struct_1_genexpr = 0;
 static PyTypeObject *__pyx_ptype_3url_3url___pyx_scope_struct_2_filter_params = 0;
 static PyTypeObject *__pyx_ptype_3url_3url___pyx_scope_struct_3_genexpr = 0;
 static PyTypeObject *__pyx_ptype_3url_3url___pyx_scope_struct_4_genexpr = 0;
 static Url::PSL __pyx_v_3url_3url_psl;
+static PyObject *__pyx_f_3url_3url_as_bytes(PyObject *); /*proto*/
 static std::string __pyx_convert_string_from_py_std__in_string(PyObject *); /*proto*/
 static CYTHON_INLINE PyObject *__pyx_convert_PyObject_string_to_py_std__in_string(std::string const &); /*proto*/
 static CYTHON_INLINE PyObject *__pyx_convert_PyUnicode_string_to_py_std__in_string(std::string const &); /*proto*/
@@ -1286,15 +1304,17 @@ int __pyx_module_is_main_url__url = 0;
 static PyObject *__pyx_builtin_ValueError;
 static PyObject *__pyx_builtin_NotImplementedError;
 static const char __pyx_k_s[] = "s";
-static const char __pyx_k__5[] = "";
-static const char __pyx_k__7[] = "=";
-static const char __pyx_k__9[] = "&";
+static const char __pyx_k__6[] = "";
+static const char __pyx_k__8[] = "=";
 static const char __pyx_k_eq[] = "__eq__";
-static const char __pyx_k__11[] = ";";
-static const char __pyx_k__13[] = "_";
+static const char __pyx_k__10[] = "&";
+static const char __pyx_k__12[] = ";";
+static const char __pyx_k__14[] = "_";
 static const char __pyx_k_cls[] = "cls";
+static const char __pyx_k_six[] = "six";
 static const char __pyx_k_url[] = "url";
 static const char __pyx_k_args[] = "args";
+static const char __pyx_k_host[] = "host";
 static const char __pyx_k_join[] = "join";
 static const char __pyx_k_keep[] = "keep";
 static const char __pyx_k_main[] = "__main__";
@@ -1322,10 +1342,12 @@ static const char __pyx_k_strict[] = "strict";
 static const char __pyx_k_genexpr[] = "genexpr";
 static const char __pyx_k_pkgutil[] = "pkgutil";
 static const char __pyx_k_set_psl[] = "set_psl";
+static const char __pyx_k_unicode[] = "unicode";
 static const char __pyx_k_url_url[] = "url.url";
 static const char __pyx_k_encoding[] = "encoding";
 static const char __pyx_k_get_data[] = "get_data";
 static const char __pyx_k_partition[] = "partition";
+static const char __pyx_k_text_type[] = "text_type";
 static const char __pyx_k_ValueError[] = "ValueError";
 static const char __pyx_k_ParseMethod[] = "ParseMethod";
 static const char __pyx_k_relative_to[] = "relative_to";
@@ -1340,11 +1362,12 @@ static const char __pyx_k_s_does_not_support_this_operati[] = "%s does not suppo
 static PyObject *__pyx_n_s_NotImplementedError;
 static PyObject *__pyx_n_s_ParseMethod;
 static PyObject *__pyx_n_s_ValueError;
-static PyObject *__pyx_kp_s__11;
-static PyObject *__pyx_n_s__13;
-static PyObject *__pyx_kp_s__5;
-static PyObject *__pyx_kp_s__7;
-static PyObject *__pyx_kp_s__9;
+static PyObject *__pyx_kp_s__10;
+static PyObject *__pyx_kp_s__12;
+static PyObject *__pyx_n_s__14;
+static PyObject *__pyx_kp_b__6;
+static PyObject *__pyx_kp_u__6;
+static PyObject *__pyx_kp_s__8;
 static PyObject *__pyx_n_s_args;
 static PyObject *__pyx_n_s_close;
 static PyObject *__pyx_n_s_cls;
@@ -1358,6 +1381,7 @@ static PyObject *__pyx_n_s_filter_params_locals_genexpr;
 static PyObject *__pyx_n_s_filter_params_locals_keep;
 static PyObject *__pyx_n_s_genexpr;
 static PyObject *__pyx_n_s_get_data;
+static PyObject *__pyx_n_s_host;
 static PyObject *__pyx_n_s_import;
 static PyObject *__pyx_n_s_join;
 static PyObject *__pyx_n_s_keep;
@@ -1378,10 +1402,13 @@ static PyObject *__pyx_n_s_s;
 static PyObject *__pyx_kp_s_s_does_not_support_this_operati;
 static PyObject *__pyx_n_s_send;
 static PyObject *__pyx_n_s_set_psl;
+static PyObject *__pyx_n_s_six;
 static PyObject *__pyx_n_s_split;
 static PyObject *__pyx_n_s_strict;
 static PyObject *__pyx_n_s_test;
+static PyObject *__pyx_n_s_text_type;
 static PyObject *__pyx_n_s_throw;
+static PyObject *__pyx_n_s_unicode;
 static PyObject *__pyx_n_s_url;
 static PyObject *__pyx_kp_s_url_URL_object_s;
 static PyObject *__pyx_n_s_url_url;
@@ -1391,55 +1418,75 @@ static PyObject *__pyx_kp_s_vagrant_url_url_pyx;
 static PyObject *__pyx_n_s_value;
 static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_cls, PyObject *__pyx_v_s, PyObject *__pyx_v_encoding); /* proto */
 static PyObject *__pyx_pf_3url_3url_2set_psl(CYTHON_UNUSED PyObject *__pyx_self, PyObject *__pyx_v_rules); /* proto */
-static int __pyx_pf_3url_3url_3URL___cinit__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, std::string __pyx_v_s); /* proto */
-static void __pyx_pf_3url_3url_3URL_2__dealloc__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_6scheme___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_6scheme_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_4host___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_4host_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_4port___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_4port_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_i); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_4path___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_4path_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_6params___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_6params_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_5query___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_5query_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_8fragment___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_8fragment_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_8userinfo___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static int __pyx_pf_3url_3url_3URL_8userinfo_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_4copy(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_encoding); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_op); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_10__str__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_12__repr__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_14canonical(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_16defrag(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_7deparam_genexpr(PyObject *__pyx_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_18deparam(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_params); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_self, PyObject *__pyx_v_query); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_2genexpr(PyObject *__pyx_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_5genexpr(PyObject *__pyx_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_function); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_22deuserinfo(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_24abspath(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_other); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_base); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_30sanitize(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_32remove_default_port(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_34escape(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_strict); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_36unescape(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_encoding); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_40punycode(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_42unpunycode(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_8hostname___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_3pld___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_3tld___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_8absolute___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_7unicode___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_pf_3url_3url_3URL_4utf8___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self); /* proto */
-static PyObject *__pyx_tp_new_3url_3url_URL(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
+static int __pyx_pf_3url_3url_9StringURL___cinit__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, std::string __pyx_v_s); /* proto */
+static void __pyx_pf_3url_3url_9StringURL_2__dealloc__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_6scheme___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_6scheme_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_4host___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_4host_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_4port___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_4port_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_i); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_4path___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_4path_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_6params___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_6params_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_5query___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_5query_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_8fragment___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_8fragment_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_8userinfo___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_9StringURL_8userinfo_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_4copy(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_6equiv(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_encoding); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_8__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_op); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_10__unicode__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_12__str__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_14__bytes__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_16__repr__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_18canonical(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_20defrag(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_7deparam_genexpr(PyObject *__pyx_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_22deparam(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_params); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_13filter_params_keep(PyObject *__pyx_self, PyObject *__pyx_v_query); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_13filter_params_2genexpr(PyObject *__pyx_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_13filter_params_5genexpr(PyObject *__pyx_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_24filter_params(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_function); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_26deuserinfo(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_28abspath(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_30relative(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_other); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_32relative_to(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_base); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_34sanitize(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_36remove_default_port(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_38escape(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_strict); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_40unescape(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_42encode(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_encoding); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_44punycode(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_46unpunycode(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_8hostname___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_3tld___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_8absolute___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_7unicode___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_9StringURL_4utf8___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_6scheme___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_6scheme_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_4host___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_4host_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_4path___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_4path_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_6params___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_6params_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_5query___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_5query_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_8fragment___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_8fragment_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_8userinfo___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static int __pyx_pf_3url_3url_10UnicodeURL_8userinfo_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3tld___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL___str__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self); /* proto */
+static PyObject *__pyx_tp_new_3url_3url_StringURL(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
+static PyObject *__pyx_tp_new_3url_3url_UnicodeURL(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new_3url_3url___pyx_scope_struct__deparam(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new_3url_3url___pyx_scope_struct_1_genexpr(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
 static PyObject *__pyx_tp_new_3url_3url___pyx_scope_struct_2_filter_params(PyTypeObject *t, PyObject *a, PyObject *k); /*proto*/
@@ -1450,19 +1497,20 @@ static PyObject *__pyx_int_3;
 static PyObject *__pyx_codeobj_;
 static PyObject *__pyx_tuple__2;
 static PyObject *__pyx_tuple__3;
-static PyObject *__pyx_tuple__6;
-static PyObject *__pyx_tuple__8;
-static PyObject *__pyx_tuple__10;
-static PyObject *__pyx_tuple__12;
-static PyObject *__pyx_tuple__14;
-static PyObject *__pyx_tuple__16;
+static PyObject *__pyx_tuple__5;
+static PyObject *__pyx_tuple__7;
+static PyObject *__pyx_tuple__9;
+static PyObject *__pyx_tuple__11;
+static PyObject *__pyx_tuple__13;
+static PyObject *__pyx_tuple__15;
 static PyObject *__pyx_tuple__17;
 static PyObject *__pyx_tuple__18;
 static PyObject *__pyx_tuple__19;
+static PyObject *__pyx_tuple__20;
 static PyObject *__pyx_codeobj__4;
-static PyObject *__pyx_codeobj__15;
+static PyObject *__pyx_codeobj__16;
 
-/* "url/url.pyx":9
+/* "url/url.pyx":11
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):             # <<<<<<<<<<<<<<
@@ -1502,7 +1550,7 @@ static PyObject *__pyx_pw_3url_3url_1ParseMethod(PyObject *__pyx_self, PyObject 
         case  1:
         if (likely((values[1] = PyDict_GetItem(__pyx_kwds, __pyx_n_s_s)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("ParseMethod", 0, 2, 3, 1); __PYX_ERR(1, 9, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("ParseMethod", 0, 2, 3, 1); __PYX_ERR(1, 11, __pyx_L3_error)
         }
         case  2:
         if (kw_args > 0) {
@@ -1511,7 +1559,7 @@ static PyObject *__pyx_pw_3url_3url_1ParseMethod(PyObject *__pyx_self, PyObject 
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "ParseMethod") < 0)) __PYX_ERR(1, 9, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "ParseMethod") < 0)) __PYX_ERR(1, 11, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -1528,7 +1576,7 @@ static PyObject *__pyx_pw_3url_3url_1ParseMethod(PyObject *__pyx_self, PyObject 
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("ParseMethod", 0, 2, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 9, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("ParseMethod", 0, 2, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 11, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("url.url.ParseMethod", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -1554,39 +1602,39 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
   PyObject *__pyx_t_7 = NULL;
   __Pyx_TraceFrameInit(__pyx_codeobj_)
   __Pyx_RefNannySetupContext("ParseMethod", 0);
-  __Pyx_TraceCall("ParseMethod", __pyx_f[1], 9, 0, __PYX_ERR(1, 9, __pyx_L1_error));
+  __Pyx_TraceCall("ParseMethod", __pyx_f[1], 11, 0, __PYX_ERR(1, 11, __pyx_L1_error));
 
-  /* "url/url.pyx":10
+  /* "url/url.pyx":12
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):
  *     if isinstance(s, bytes):             # <<<<<<<<<<<<<<
  *         if encoding == 'utf-8':
  *             return cls(s)
  */
-  __Pyx_TraceLine(10,0,__PYX_ERR(1, 10, __pyx_L1_error))
+  __Pyx_TraceLine(12,0,__PYX_ERR(1, 12, __pyx_L1_error))
   __pyx_t_1 = PyBytes_Check(__pyx_v_s); 
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "url/url.pyx":11
+    /* "url/url.pyx":13
  * def ParseMethod(cls, s, encoding='utf-8'):
  *     if isinstance(s, bytes):
  *         if encoding == 'utf-8':             # <<<<<<<<<<<<<<
  *             return cls(s)
  *         else:
  */
-    __Pyx_TraceLine(11,0,__PYX_ERR(1, 11, __pyx_L1_error))
-    __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_encoding, __pyx_kp_s_utf_8, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 11, __pyx_L1_error)
+    __Pyx_TraceLine(13,0,__PYX_ERR(1, 13, __pyx_L1_error))
+    __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_encoding, __pyx_kp_s_utf_8, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 13, __pyx_L1_error)
     if (__pyx_t_2) {
 
-      /* "url/url.pyx":12
+      /* "url/url.pyx":14
  *     if isinstance(s, bytes):
  *         if encoding == 'utf-8':
  *             return cls(s)             # <<<<<<<<<<<<<<
  *         else:
  *             return cls(s.decode(encoding).encode('utf-8'))
  */
-      __Pyx_TraceLine(12,0,__PYX_ERR(1, 12, __pyx_L1_error))
+      __Pyx_TraceLine(14,0,__PYX_ERR(1, 14, __pyx_L1_error))
       __Pyx_XDECREF(__pyx_r);
       __Pyx_INCREF(__pyx_v_cls);
       __pyx_t_4 = __pyx_v_cls; __pyx_t_5 = NULL;
@@ -1600,16 +1648,16 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
         }
       }
       if (!__pyx_t_5) {
-        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_s); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 12, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_v_s); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 14, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
       } else {
-        __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 12, __pyx_L1_error)
+        __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 14, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_6);
         __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5); __pyx_t_5 = NULL;
         __Pyx_INCREF(__pyx_v_s);
         __Pyx_GIVEREF(__pyx_v_s);
         PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_s);
-        __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 12, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 14, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
       }
@@ -1618,7 +1666,7 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
       __pyx_t_3 = 0;
       goto __pyx_L0;
 
-      /* "url/url.pyx":11
+      /* "url/url.pyx":13
  * def ParseMethod(cls, s, encoding='utf-8'):
  *     if isinstance(s, bytes):
  *         if encoding == 'utf-8':             # <<<<<<<<<<<<<<
@@ -1627,17 +1675,17 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
  */
     }
 
-    /* "url/url.pyx":14
+    /* "url/url.pyx":16
  *             return cls(s)
  *         else:
  *             return cls(s.decode(encoding).encode('utf-8'))             # <<<<<<<<<<<<<<
  *     else:
  *         return cls(s.encode('utf-8'))
  */
-    __Pyx_TraceLine(14,0,__PYX_ERR(1, 14, __pyx_L1_error))
+    __Pyx_TraceLine(16,0,__PYX_ERR(1, 16, __pyx_L1_error))
     /*else*/ {
       __Pyx_XDECREF(__pyx_r);
-      __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_decode); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 14, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_decode); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 16, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __pyx_t_5 = NULL;
       if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_6))) {
@@ -1650,24 +1698,24 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
         }
       }
       if (!__pyx_t_5) {
-        __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_v_encoding); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 14, __pyx_L1_error)
+        __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_v_encoding); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 16, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
       } else {
-        __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 14, __pyx_L1_error)
+        __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 16, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_7);
         __Pyx_GIVEREF(__pyx_t_5); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_5); __pyx_t_5 = NULL;
         __Pyx_INCREF(__pyx_v_encoding);
         __Pyx_GIVEREF(__pyx_v_encoding);
         PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_v_encoding);
-        __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 14, __pyx_L1_error)
+        __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 16, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
       }
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-      __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_encode); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 14, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_encode); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 16, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 14, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__2, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 16, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_INCREF(__pyx_v_cls);
@@ -1682,17 +1730,17 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
         }
       }
       if (!__pyx_t_7) {
-        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 14, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 16, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
         __Pyx_GOTREF(__pyx_t_3);
       } else {
-        __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 14, __pyx_L1_error)
+        __pyx_t_5 = PyTuple_New(1+1); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 16, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
         __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_7); __pyx_t_7 = NULL;
         __Pyx_GIVEREF(__pyx_t_4);
         PyTuple_SET_ITEM(__pyx_t_5, 0+1, __pyx_t_4);
         __pyx_t_4 = 0;
-        __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_5, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 14, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_5, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 16, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       }
@@ -1702,7 +1750,7 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
       goto __pyx_L0;
     }
 
-    /* "url/url.pyx":10
+    /* "url/url.pyx":12
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):
  *     if isinstance(s, bytes):             # <<<<<<<<<<<<<<
@@ -1711,19 +1759,19 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
  */
   }
 
-  /* "url/url.pyx":16
+  /* "url/url.pyx":18
  *             return cls(s.decode(encoding).encode('utf-8'))
  *     else:
  *         return cls(s.encode('utf-8'))             # <<<<<<<<<<<<<<
  * 
  * def set_psl(rules):
  */
-  __Pyx_TraceLine(16,0,__PYX_ERR(1, 16, __pyx_L1_error))
+  __Pyx_TraceLine(18,0,__PYX_ERR(1, 18, __pyx_L1_error))
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_encode); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 16, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_s, __pyx_n_s_encode); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 18, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__3, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 16, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_tuple__3, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 18, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_INCREF(__pyx_v_cls);
@@ -1738,17 +1786,17 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
       }
     }
     if (!__pyx_t_4) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 16, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 18, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 16, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 18, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_4); __pyx_t_4 = NULL;
       __Pyx_GIVEREF(__pyx_t_5);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_t_5);
       __pyx_t_5 = 0;
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 16, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 18, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
@@ -1758,7 +1806,7 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
     goto __pyx_L0;
   }
 
-  /* "url/url.pyx":9
+  /* "url/url.pyx":11
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):             # <<<<<<<<<<<<<<
@@ -1782,12 +1830,12 @@ static PyObject *__pyx_pf_3url_3url_ParseMethod(CYTHON_UNUSED PyObject *__pyx_se
   return __pyx_r;
 }
 
-/* "url/url.pyx":18
+/* "url/url.pyx":20
  *         return cls(s.encode('utf-8'))
  * 
  * def set_psl(rules):             # <<<<<<<<<<<<<<
  *     global psl
- *     psl = PSL.fromString(rules)
+ *     psl = PSL.fromString(as_bytes(rules))
  */
 
 /* Python wrapper */
@@ -1808,34 +1856,39 @@ static PyObject *__pyx_pf_3url_3url_2set_psl(CYTHON_UNUSED PyObject *__pyx_self,
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_TraceFrameInit(__pyx_codeobj__4)
   __Pyx_RefNannySetupContext("set_psl", 0);
-  __Pyx_TraceCall("set_psl", __pyx_f[1], 18, 0, __PYX_ERR(1, 18, __pyx_L1_error));
+  __Pyx_TraceCall("set_psl", __pyx_f[1], 20, 0, __PYX_ERR(1, 20, __pyx_L1_error));
 
-  /* "url/url.pyx":20
+  /* "url/url.pyx":22
  * def set_psl(rules):
  *     global psl
- *     psl = PSL.fromString(rules)             # <<<<<<<<<<<<<<
+ *     psl = PSL.fromString(as_bytes(rules))             # <<<<<<<<<<<<<<
  * 
- * 
+ * cdef as_bytes(obj):
  */
-  __Pyx_TraceLine(20,0,__PYX_ERR(1, 20, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_rules); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 20, __pyx_L1_error)
-  __pyx_v_3url_3url_psl = Url::PSL::fromString(__pyx_t_1);
+  __Pyx_TraceLine(22,0,__PYX_ERR(1, 22, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_rules); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 22, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 22, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_3url_3url_psl = Url::PSL::fromString(__pyx_t_2);
 
-  /* "url/url.pyx":18
+  /* "url/url.pyx":20
  *         return cls(s.encode('utf-8'))
  * 
  * def set_psl(rules):             # <<<<<<<<<<<<<<
  *     global psl
- *     psl = PSL.fromString(rules)
+ *     psl = PSL.fromString(as_bytes(rules))
  */
 
   /* function exit code */
   __pyx_r = Py_None; __Pyx_INCREF(Py_None);
   goto __pyx_L0;
   __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
   __Pyx_AddTraceback("url.url.set_psl", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -1845,7 +1898,102 @@ static PyObject *__pyx_pf_3url_3url_2set_psl(CYTHON_UNUSED PyObject *__pyx_self,
   return __pyx_r;
 }
 
-/* "url/url.pyx":30
+/* "url/url.pyx":24
+ *     psl = PSL.fromString(as_bytes(rules))
+ * 
+ * cdef as_bytes(obj):             # <<<<<<<<<<<<<<
+ *     if isinstance(obj, text_type):
+ *         return obj.encode('utf-8')
+ */
+
+static PyObject *__pyx_f_3url_3url_as_bytes(PyObject *__pyx_v_obj) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  int __pyx_t_2;
+  int __pyx_t_3;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("as_bytes", 0);
+  __Pyx_TraceCall("as_bytes", __pyx_f[1], 24, 0, __PYX_ERR(1, 24, __pyx_L1_error));
+
+  /* "url/url.pyx":25
+ * 
+ * cdef as_bytes(obj):
+ *     if isinstance(obj, text_type):             # <<<<<<<<<<<<<<
+ *         return obj.encode('utf-8')
+ *     return obj
+ */
+  __Pyx_TraceLine(25,0,__PYX_ERR(1, 25, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 25, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = PyObject_IsInstance(__pyx_v_obj, __pyx_t_1); if (unlikely(__pyx_t_2 == -1)) __PYX_ERR(1, 25, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_t_3 = (__pyx_t_2 != 0);
+  if (__pyx_t_3) {
+
+    /* "url/url.pyx":26
+ * cdef as_bytes(obj):
+ *     if isinstance(obj, text_type):
+ *         return obj.encode('utf-8')             # <<<<<<<<<<<<<<
+ *     return obj
+ * 
+ */
+    __Pyx_TraceLine(26,0,__PYX_ERR(1, 26, __pyx_L1_error))
+    __Pyx_XDECREF(__pyx_r);
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_obj, __pyx_n_s_encode); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 26, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_1);
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_tuple__5, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 26, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_4);
+    __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+    __pyx_r = __pyx_t_4;
+    __pyx_t_4 = 0;
+    goto __pyx_L0;
+
+    /* "url/url.pyx":25
+ * 
+ * cdef as_bytes(obj):
+ *     if isinstance(obj, text_type):             # <<<<<<<<<<<<<<
+ *         return obj.encode('utf-8')
+ *     return obj
+ */
+  }
+
+  /* "url/url.pyx":27
+ *     if isinstance(obj, text_type):
+ *         return obj.encode('utf-8')
+ *     return obj             # <<<<<<<<<<<<<<
+ * 
+ * cdef class StringURL:
+ */
+  __Pyx_TraceLine(27,0,__PYX_ERR(1, 27, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(__pyx_v_obj);
+  __pyx_r = __pyx_v_obj;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":24
+ *     psl = PSL.fromString(as_bytes(rules))
+ * 
+ * cdef as_bytes(obj):             # <<<<<<<<<<<<<<
+ *     if isinstance(obj, text_type):
+ *         return obj.encode('utf-8')
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.as_bytes", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = 0;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":36
  *     parse = classmethod(ParseMethod)
  * 
  *     def __cinit__(self, const string& s):             # <<<<<<<<<<<<<<
@@ -1854,8 +2002,8 @@ static PyObject *__pyx_pf_3url_3url_2set_psl(CYTHON_UNUSED PyObject *__pyx_self,
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_1__cinit__(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static int __pyx_pw_3url_3url_3URL_1__cinit__(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
+static int __pyx_pw_3url_3url_9StringURL_1__cinit__(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_1__cinit__(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   std::string __pyx_v_s;
   int __pyx_r;
   __Pyx_RefNannyDeclarations
@@ -1878,55 +2026,55 @@ static int __pyx_pw_3url_3url_3URL_1__cinit__(PyObject *__pyx_v_self, PyObject *
         else goto __pyx_L5_argtuple_error;
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(1, 30, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "__cinit__") < 0)) __PYX_ERR(1, 36, __pyx_L3_error)
       }
     } else if (PyTuple_GET_SIZE(__pyx_args) != 1) {
       goto __pyx_L5_argtuple_error;
     } else {
       values[0] = PyTuple_GET_ITEM(__pyx_args, 0);
     }
-    __pyx_v_s = __pyx_convert_string_from_py_std__in_string(values[0]); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 30, __pyx_L3_error)
+    __pyx_v_s = __pyx_convert_string_from_py_std__in_string(values[0]); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 36, __pyx_L3_error)
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 30, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("__cinit__", 1, 1, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 36, __pyx_L3_error)
   __pyx_L3_error:;
-  __Pyx_AddTraceback("url.url.URL.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return -1;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_3url_3url_3URL___cinit__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), __pyx_v_s);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL___cinit__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), __pyx_v_s);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL___cinit__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, std::string __pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL___cinit__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, std::string __pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   Url::Url *__pyx_t_1;
   __Pyx_RefNannySetupContext("__cinit__", 0);
-  __Pyx_TraceCall("__cinit__", __pyx_f[1], 30, 0, __PYX_ERR(1, 30, __pyx_L1_error));
+  __Pyx_TraceCall("__cinit__", __pyx_f[1], 36, 0, __PYX_ERR(1, 36, __pyx_L1_error));
 
-  /* "url/url.pyx":31
+  /* "url/url.pyx":37
  * 
  *     def __cinit__(self, const string& s):
  *         self.ptr = new Url(s)             # <<<<<<<<<<<<<<
  * 
  *     def __dealloc__(self):
  */
-  __Pyx_TraceLine(31,0,__PYX_ERR(1, 31, __pyx_L1_error))
+  __Pyx_TraceLine(37,0,__PYX_ERR(1, 37, __pyx_L1_error))
   try {
     __pyx_t_1 = new Url::Url(__pyx_v_s);
   } catch(...) {
     try { throw; } catch(const std::exception& exn) { PyErr_SetString(__pyx_builtin_ValueError, exn.what()); } catch(...) { PyErr_SetNone(__pyx_builtin_ValueError); }
-    __PYX_ERR(1, 31, __pyx_L1_error)
+    __PYX_ERR(1, 37, __pyx_L1_error)
   }
   __pyx_v_self->ptr = __pyx_t_1;
 
-  /* "url/url.pyx":30
+  /* "url/url.pyx":36
  *     parse = classmethod(ParseMethod)
  * 
  *     def __cinit__(self, const string& s):             # <<<<<<<<<<<<<<
@@ -1938,7 +2086,7 @@ static int __pyx_pf_3url_3url_3URL___cinit__(struct __pyx_obj_3url_3url_URL *__p
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.__cinit__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -1946,7 +2094,7 @@ static int __pyx_pf_3url_3url_3URL___cinit__(struct __pyx_obj_3url_3url_URL *__p
   return __pyx_r;
 }
 
-/* "url/url.pyx":33
+/* "url/url.pyx":39
  *         self.ptr = new Url(s)
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -1955,33 +2103,33 @@ static int __pyx_pf_3url_3url_3URL___cinit__(struct __pyx_obj_3url_3url_URL *__p
  */
 
 /* Python wrapper */
-static void __pyx_pw_3url_3url_3URL_3__dealloc__(PyObject *__pyx_v_self); /*proto*/
-static void __pyx_pw_3url_3url_3URL_3__dealloc__(PyObject *__pyx_v_self) {
+static void __pyx_pw_3url_3url_9StringURL_3__dealloc__(PyObject *__pyx_v_self); /*proto*/
+static void __pyx_pw_3url_3url_9StringURL_3__dealloc__(PyObject *__pyx_v_self) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__dealloc__ (wrapper)", 0);
-  __pyx_pf_3url_3url_3URL_2__dealloc__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_pf_3url_3url_9StringURL_2__dealloc__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
 }
 
-static void __pyx_pf_3url_3url_3URL_2__dealloc__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static void __pyx_pf_3url_3url_9StringURL_2__dealloc__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__dealloc__", 0);
-  __Pyx_TraceCall("__dealloc__", __pyx_f[1], 33, 0, __PYX_ERR(1, 33, __pyx_L1_error));
+  __Pyx_TraceCall("__dealloc__", __pyx_f[1], 39, 0, __PYX_ERR(1, 39, __pyx_L1_error));
 
-  /* "url/url.pyx":34
+  /* "url/url.pyx":40
  * 
  *     def __dealloc__(self):
  *         del self.ptr             # <<<<<<<<<<<<<<
  * 
  *     property scheme:
  */
-  __Pyx_TraceLine(34,0,__PYX_ERR(1, 34, __pyx_L1_error))
+  __Pyx_TraceLine(40,0,__PYX_ERR(1, 40, __pyx_L1_error))
   delete __pyx_v_self->ptr;
 
-  /* "url/url.pyx":33
+  /* "url/url.pyx":39
  *         self.ptr = new Url(s)
  * 
  *     def __dealloc__(self):             # <<<<<<<<<<<<<<
@@ -1992,158 +2140,34 @@ static void __pyx_pf_3url_3url_3URL_2__dealloc__(struct __pyx_obj_3url_3url_URL 
   /* function exit code */
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_WriteUnraisable("url.url.URL.__dealloc__", __pyx_clineno, __pyx_lineno, __pyx_filename, 0, 0);
+  __Pyx_WriteUnraisable("url.url.StringURL.__dealloc__", __pyx_clineno, __pyx_lineno, __pyx_filename, 0, 0);
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
   __Pyx_RefNannyFinishContext();
-}
-
-/* "url/url.pyx":37
- * 
- *     property scheme:
- *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.scheme()
- *         def __set__(self, s):
- */
-
-/* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_6scheme_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_6scheme_1__get__(PyObject *__pyx_v_self) {
-  PyObject *__pyx_r = 0;
-  __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_6scheme___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
-
-  /* function exit code */
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-static PyObject *__pyx_pf_3url_3url_3URL_6scheme___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
-  PyObject *__pyx_r = NULL;
-  __Pyx_TraceDeclarations
-  __Pyx_RefNannyDeclarations
-  PyObject *__pyx_t_1 = NULL;
-  __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 37, 0, __PYX_ERR(1, 37, __pyx_L1_error));
-
-  /* "url/url.pyx":38
- *     property scheme:
- *         def __get__(self):
- *             return self.ptr.scheme()             # <<<<<<<<<<<<<<
- *         def __set__(self, s):
- *             self.ptr.setScheme(s)
- */
-  __Pyx_TraceLine(38,0,__PYX_ERR(1, 38, __pyx_L1_error))
-  __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->scheme()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 38, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_r = __pyx_t_1;
-  __pyx_t_1 = 0;
-  goto __pyx_L0;
-
-  /* "url/url.pyx":37
- * 
- *     property scheme:
- *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.scheme()
- *         def __set__(self, s):
- */
-
-  /* function exit code */
-  __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.scheme.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_r = NULL;
-  __pyx_L0:;
-  __Pyx_XGIVEREF(__pyx_r);
-  __Pyx_TraceReturn(__pyx_r, 0);
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-/* "url/url.pyx":39
- *         def __get__(self):
- *             return self.ptr.scheme()
- *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setScheme(s)
- * 
- */
-
-/* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_6scheme_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_6scheme_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
-  int __pyx_r;
-  __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_6scheme_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
-
-  /* function exit code */
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-static int __pyx_pf_3url_3url_3URL_6scheme_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
-  int __pyx_r;
-  __Pyx_TraceDeclarations
-  __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
-  __Pyx_RefNannySetupContext("__set__", 0);
-  __Pyx_TraceCall("__set__", __pyx_f[1], 39, 0, __PYX_ERR(1, 39, __pyx_L1_error));
-
-  /* "url/url.pyx":40
- *             return self.ptr.scheme()
- *         def __set__(self, s):
- *             self.ptr.setScheme(s)             # <<<<<<<<<<<<<<
- * 
- *     property host:
- */
-  __Pyx_TraceLine(40,0,__PYX_ERR(1, 40, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 40, __pyx_L1_error)
-  __pyx_v_self->ptr->setScheme(__pyx_t_1);
-
-  /* "url/url.pyx":39
- *         def __get__(self):
- *             return self.ptr.scheme()
- *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setScheme(s)
- * 
- */
-
-  /* function exit code */
-  __pyx_r = 0;
-  goto __pyx_L0;
-  __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.scheme.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_r = -1;
-  __pyx_L0:;
-  __Pyx_TraceReturn(Py_None, 0);
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
 }
 
 /* "url/url.pyx":43
  * 
- *     property host:
+ *     property scheme:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.host()
+ *             return self.ptr.scheme()
  *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_4host_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_4host_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_6scheme_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_6scheme_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4host___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_6scheme___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_4host___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_6scheme___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2152,15 +2176,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_4host___get__(struct __pyx_obj_3url_3ur
   __Pyx_TraceCall("__get__", __pyx_f[1], 43, 0, __PYX_ERR(1, 43, __pyx_L1_error));
 
   /* "url/url.pyx":44
- *     property host:
+ *     property scheme:
  *         def __get__(self):
- *             return self.ptr.host()             # <<<<<<<<<<<<<<
+ *             return self.ptr.scheme()             # <<<<<<<<<<<<<<
  *         def __set__(self, s):
- *             self.ptr.setHost(s)
+ *             self.ptr.setScheme(as_bytes(s))
  */
   __Pyx_TraceLine(44,0,__PYX_ERR(1, 44, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->host()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 44, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->scheme()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 44, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2168,16 +2192,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_4host___get__(struct __pyx_obj_3url_3ur
 
   /* "url/url.pyx":43
  * 
- *     property host:
+ *     property scheme:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.host()
+ *             return self.ptr.scheme()
  *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.host.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.scheme.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2188,49 +2212,53 @@ static PyObject *__pyx_pf_3url_3url_3URL_4host___get__(struct __pyx_obj_3url_3ur
 
 /* "url/url.pyx":45
  *         def __get__(self):
- *             return self.ptr.host()
+ *             return self.ptr.scheme()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setHost(s)
+ *             self.ptr.setScheme(as_bytes(s))
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_4host_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_4host_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pw_3url_3url_9StringURL_6scheme_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_6scheme_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4host_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_6scheme_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_4host_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL_6scheme_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 45, 0, __PYX_ERR(1, 45, __pyx_L1_error));
 
   /* "url/url.pyx":46
- *             return self.ptr.host()
+ *             return self.ptr.scheme()
  *         def __set__(self, s):
- *             self.ptr.setHost(s)             # <<<<<<<<<<<<<<
+ *             self.ptr.setScheme(as_bytes(s))             # <<<<<<<<<<<<<<
  * 
- *     property port:
+ *     property host:
  */
   __Pyx_TraceLine(46,0,__PYX_ERR(1, 46, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 46, __pyx_L1_error)
-  __pyx_v_self->ptr->setHost(__pyx_t_1);
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 46, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 46, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setScheme(__pyx_t_2);
 
   /* "url/url.pyx":45
  *         def __get__(self):
- *             return self.ptr.host()
+ *             return self.ptr.scheme()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setHost(s)
+ *             self.ptr.setScheme(as_bytes(s))
  * 
  */
 
@@ -2238,7 +2266,8 @@ static int __pyx_pf_3url_3url_3URL_4host_2__set__(struct __pyx_obj_3url_3url_URL
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.host.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.scheme.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2248,26 +2277,26 @@ static int __pyx_pf_3url_3url_3URL_4host_2__set__(struct __pyx_obj_3url_3url_URL
 
 /* "url/url.pyx":49
  * 
- *     property port:
+ *     property host:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.port()
- *         def __set__(self, i):
+ *             return self.ptr.host()
+ *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_4port_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_4port_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_4host_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_4host_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4port___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4host___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_4port___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_4host___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2276,15 +2305,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_4port___get__(struct __pyx_obj_3url_3ur
   __Pyx_TraceCall("__get__", __pyx_f[1], 49, 0, __PYX_ERR(1, 49, __pyx_L1_error));
 
   /* "url/url.pyx":50
- *     property port:
+ *     property host:
  *         def __get__(self):
- *             return self.ptr.port()             # <<<<<<<<<<<<<<
- *         def __set__(self, i):
- *             self.ptr.setPort(i)
+ *             return self.ptr.host()             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setHost(as_bytes(s))
  */
   __Pyx_TraceLine(50,0,__PYX_ERR(1, 50, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->ptr->port()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 50, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->host()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 50, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2292,16 +2321,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_4port___get__(struct __pyx_obj_3url_3ur
 
   /* "url/url.pyx":49
  * 
- *     property port:
+ *     property host:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.port()
- *         def __set__(self, i):
+ *             return self.ptr.host()
+ *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.port.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.host.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2312,49 +2341,53 @@ static PyObject *__pyx_pf_3url_3url_3URL_4port___get__(struct __pyx_obj_3url_3ur
 
 /* "url/url.pyx":51
  *         def __get__(self):
- *             return self.ptr.port()
- *         def __set__(self, i):             # <<<<<<<<<<<<<<
- *             self.ptr.setPort(i)
+ *             return self.ptr.host()
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setHost(as_bytes(s))
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_4port_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_i); /*proto*/
-static int __pyx_pw_3url_3url_3URL_4port_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_i) {
+static int __pyx_pw_3url_3url_9StringURL_4host_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_4host_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4port_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_i));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4host_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_4port_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_i) {
+static int __pyx_pf_3url_3url_9StringURL_4host_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  int __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 51, 0, __PYX_ERR(1, 51, __pyx_L1_error));
 
   /* "url/url.pyx":52
- *             return self.ptr.port()
- *         def __set__(self, i):
- *             self.ptr.setPort(i)             # <<<<<<<<<<<<<<
+ *             return self.ptr.host()
+ *         def __set__(self, s):
+ *             self.ptr.setHost(as_bytes(s))             # <<<<<<<<<<<<<<
  * 
- *     property path:
+ *     property port:
  */
   __Pyx_TraceLine(52,0,__PYX_ERR(1, 52, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyInt_As_int(__pyx_v_i); if (unlikely((__pyx_t_1 == (int)-1) && PyErr_Occurred())) __PYX_ERR(1, 52, __pyx_L1_error)
-  __pyx_v_self->ptr->setPort(__pyx_t_1);
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 52, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 52, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setHost(__pyx_t_2);
 
   /* "url/url.pyx":51
  *         def __get__(self):
- *             return self.ptr.port()
- *         def __set__(self, i):             # <<<<<<<<<<<<<<
- *             self.ptr.setPort(i)
+ *             return self.ptr.host()
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setHost(as_bytes(s))
  * 
  */
 
@@ -2362,7 +2395,8 @@ static int __pyx_pf_3url_3url_3URL_4port_2__set__(struct __pyx_obj_3url_3url_URL
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.port.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.host.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2372,26 +2406,26 @@ static int __pyx_pf_3url_3url_3URL_4port_2__set__(struct __pyx_obj_3url_3url_URL
 
 /* "url/url.pyx":55
  * 
- *     property path:
+ *     property port:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.path()
- *         def __set__(self, s):
+ *             return self.ptr.port()
+ *         def __set__(self, i):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_4path_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_4path_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_4port_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_4port_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4path___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4port___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_4path___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_4port___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2400,15 +2434,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_4path___get__(struct __pyx_obj_3url_3ur
   __Pyx_TraceCall("__get__", __pyx_f[1], 55, 0, __PYX_ERR(1, 55, __pyx_L1_error));
 
   /* "url/url.pyx":56
- *     property path:
+ *     property port:
  *         def __get__(self):
- *             return self.ptr.path()             # <<<<<<<<<<<<<<
- *         def __set__(self, s):
- *             self.ptr.setPath(s)
+ *             return self.ptr.port()             # <<<<<<<<<<<<<<
+ *         def __set__(self, i):
+ *             self.ptr.setPort(i)
  */
   __Pyx_TraceLine(56,0,__PYX_ERR(1, 56, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->path()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 56, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_int(__pyx_v_self->ptr->port()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 56, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2416,16 +2450,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_4path___get__(struct __pyx_obj_3url_3ur
 
   /* "url/url.pyx":55
  * 
- *     property path:
+ *     property port:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.path()
- *         def __set__(self, s):
+ *             return self.ptr.port()
+ *         def __set__(self, i):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.path.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.port.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2436,49 +2470,49 @@ static PyObject *__pyx_pf_3url_3url_3URL_4path___get__(struct __pyx_obj_3url_3ur
 
 /* "url/url.pyx":57
  *         def __get__(self):
- *             return self.ptr.path()
- *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setPath(s)
+ *             return self.ptr.port()
+ *         def __set__(self, i):             # <<<<<<<<<<<<<<
+ *             self.ptr.setPort(i)
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_4path_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_4path_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pw_3url_3url_9StringURL_4port_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_i); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_4port_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_i) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4path_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4port_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_i));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_4path_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL_4port_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_i) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  int __pyx_t_1;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 57, 0, __PYX_ERR(1, 57, __pyx_L1_error));
 
   /* "url/url.pyx":58
- *             return self.ptr.path()
- *         def __set__(self, s):
- *             self.ptr.setPath(s)             # <<<<<<<<<<<<<<
+ *             return self.ptr.port()
+ *         def __set__(self, i):
+ *             self.ptr.setPort(i)             # <<<<<<<<<<<<<<
  * 
- *     property params:
+ *     property path:
  */
   __Pyx_TraceLine(58,0,__PYX_ERR(1, 58, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 58, __pyx_L1_error)
-  __pyx_v_self->ptr->setPath(__pyx_t_1);
+  __pyx_t_1 = __Pyx_PyInt_As_int(__pyx_v_i); if (unlikely((__pyx_t_1 == (int)-1) && PyErr_Occurred())) __PYX_ERR(1, 58, __pyx_L1_error)
+  __pyx_v_self->ptr->setPort(__pyx_t_1);
 
   /* "url/url.pyx":57
  *         def __get__(self):
- *             return self.ptr.path()
- *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setPath(s)
+ *             return self.ptr.port()
+ *         def __set__(self, i):             # <<<<<<<<<<<<<<
+ *             self.ptr.setPort(i)
  * 
  */
 
@@ -2486,7 +2520,7 @@ static int __pyx_pf_3url_3url_3URL_4path_2__set__(struct __pyx_obj_3url_3url_URL
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.path.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.port.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2496,26 +2530,26 @@ static int __pyx_pf_3url_3url_3URL_4path_2__set__(struct __pyx_obj_3url_3url_URL
 
 /* "url/url.pyx":61
  * 
- *     property params:
+ *     property path:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.params()
+ *             return self.ptr.path()
  *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_6params_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_6params_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_4path_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_4path_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_6params___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4path___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_6params___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_4path___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2524,15 +2558,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_6params___get__(struct __pyx_obj_3url_3
   __Pyx_TraceCall("__get__", __pyx_f[1], 61, 0, __PYX_ERR(1, 61, __pyx_L1_error));
 
   /* "url/url.pyx":62
- *     property params:
+ *     property path:
  *         def __get__(self):
- *             return self.ptr.params()             # <<<<<<<<<<<<<<
+ *             return self.ptr.path()             # <<<<<<<<<<<<<<
  *         def __set__(self, s):
- *             self.ptr.setParams(s)
+ *             self.ptr.setPath(as_bytes(s))
  */
   __Pyx_TraceLine(62,0,__PYX_ERR(1, 62, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->params()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 62, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->path()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 62, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2540,16 +2574,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_6params___get__(struct __pyx_obj_3url_3
 
   /* "url/url.pyx":61
  * 
- *     property params:
+ *     property path:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.params()
+ *             return self.ptr.path()
  *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.params.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.path.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2560,49 +2594,53 @@ static PyObject *__pyx_pf_3url_3url_3URL_6params___get__(struct __pyx_obj_3url_3
 
 /* "url/url.pyx":63
  *         def __get__(self):
- *             return self.ptr.params()
+ *             return self.ptr.path()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setParams(s)
+ *             self.ptr.setPath(as_bytes(s))
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_6params_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_6params_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pw_3url_3url_9StringURL_4path_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_4path_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_6params_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4path_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_6params_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL_4path_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 63, 0, __PYX_ERR(1, 63, __pyx_L1_error));
 
   /* "url/url.pyx":64
- *             return self.ptr.params()
+ *             return self.ptr.path()
  *         def __set__(self, s):
- *             self.ptr.setParams(s)             # <<<<<<<<<<<<<<
+ *             self.ptr.setPath(as_bytes(s))             # <<<<<<<<<<<<<<
  * 
- *     property query:
+ *     property params:
  */
   __Pyx_TraceLine(64,0,__PYX_ERR(1, 64, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 64, __pyx_L1_error)
-  __pyx_v_self->ptr->setParams(__pyx_t_1);
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 64, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 64, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setPath(__pyx_t_2);
 
   /* "url/url.pyx":63
  *         def __get__(self):
- *             return self.ptr.params()
+ *             return self.ptr.path()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setParams(s)
+ *             self.ptr.setPath(as_bytes(s))
  * 
  */
 
@@ -2610,7 +2648,8 @@ static int __pyx_pf_3url_3url_3URL_6params_2__set__(struct __pyx_obj_3url_3url_U
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.params.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.path.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2620,26 +2659,26 @@ static int __pyx_pf_3url_3url_3URL_6params_2__set__(struct __pyx_obj_3url_3url_U
 
 /* "url/url.pyx":67
  * 
- *     property query:
+ *     property params:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.query()
+ *             return self.ptr.params()
  *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_5query_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_5query_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_6params_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_6params_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_5query___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_6params___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_5query___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_6params___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2648,15 +2687,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_5query___get__(struct __pyx_obj_3url_3u
   __Pyx_TraceCall("__get__", __pyx_f[1], 67, 0, __PYX_ERR(1, 67, __pyx_L1_error));
 
   /* "url/url.pyx":68
- *     property query:
+ *     property params:
  *         def __get__(self):
- *             return self.ptr.query()             # <<<<<<<<<<<<<<
+ *             return self.ptr.params()             # <<<<<<<<<<<<<<
  *         def __set__(self, s):
- *             self.ptr.setQuery(s)
+ *             self.ptr.setParams(as_bytes(s))
  */
   __Pyx_TraceLine(68,0,__PYX_ERR(1, 68, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->query()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 68, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->params()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 68, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2664,16 +2703,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_5query___get__(struct __pyx_obj_3url_3u
 
   /* "url/url.pyx":67
  * 
- *     property query:
+ *     property params:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.query()
+ *             return self.ptr.params()
  *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.query.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.params.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2684,49 +2723,53 @@ static PyObject *__pyx_pf_3url_3url_3URL_5query___get__(struct __pyx_obj_3url_3u
 
 /* "url/url.pyx":69
  *         def __get__(self):
- *             return self.ptr.query()
+ *             return self.ptr.params()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setQuery(s)
+ *             self.ptr.setParams(as_bytes(s))
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_5query_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_5query_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pw_3url_3url_9StringURL_6params_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_6params_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_5query_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_6params_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_5query_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL_6params_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 69, 0, __PYX_ERR(1, 69, __pyx_L1_error));
 
   /* "url/url.pyx":70
- *             return self.ptr.query()
+ *             return self.ptr.params()
  *         def __set__(self, s):
- *             self.ptr.setQuery(s)             # <<<<<<<<<<<<<<
+ *             self.ptr.setParams(as_bytes(s))             # <<<<<<<<<<<<<<
  * 
- *     property fragment:
+ *     property query:
  */
   __Pyx_TraceLine(70,0,__PYX_ERR(1, 70, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 70, __pyx_L1_error)
-  __pyx_v_self->ptr->setQuery(__pyx_t_1);
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 70, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 70, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setParams(__pyx_t_2);
 
   /* "url/url.pyx":69
  *         def __get__(self):
- *             return self.ptr.query()
+ *             return self.ptr.params()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setQuery(s)
+ *             self.ptr.setParams(as_bytes(s))
  * 
  */
 
@@ -2734,7 +2777,8 @@ static int __pyx_pf_3url_3url_3URL_5query_2__set__(struct __pyx_obj_3url_3url_UR
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.query.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.params.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2744,26 +2788,26 @@ static int __pyx_pf_3url_3url_3URL_5query_2__set__(struct __pyx_obj_3url_3url_UR
 
 /* "url/url.pyx":73
  * 
- *     property fragment:
+ *     property query:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.fragment()
+ *             return self.ptr.query()
  *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_8fragment_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_8fragment_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_5query_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_5query_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_8fragment___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_5query___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_8fragment___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_5query___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2772,15 +2816,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_8fragment___get__(struct __pyx_obj_3url
   __Pyx_TraceCall("__get__", __pyx_f[1], 73, 0, __PYX_ERR(1, 73, __pyx_L1_error));
 
   /* "url/url.pyx":74
- *     property fragment:
+ *     property query:
  *         def __get__(self):
- *             return self.ptr.fragment()             # <<<<<<<<<<<<<<
+ *             return self.ptr.query()             # <<<<<<<<<<<<<<
  *         def __set__(self, s):
- *             self.ptr.setFragment(s)
+ *             self.ptr.setQuery(as_bytes(s))
  */
   __Pyx_TraceLine(74,0,__PYX_ERR(1, 74, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->fragment()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 74, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->query()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 74, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2788,16 +2832,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_8fragment___get__(struct __pyx_obj_3url
 
   /* "url/url.pyx":73
  * 
- *     property fragment:
+ *     property query:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.fragment()
+ *             return self.ptr.query()
  *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.fragment.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.query.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2808,49 +2852,53 @@ static PyObject *__pyx_pf_3url_3url_3URL_8fragment___get__(struct __pyx_obj_3url
 
 /* "url/url.pyx":75
  *         def __get__(self):
- *             return self.ptr.fragment()
+ *             return self.ptr.query()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setFragment(s)
+ *             self.ptr.setQuery(as_bytes(s))
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_8fragment_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_8fragment_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pw_3url_3url_9StringURL_5query_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_5query_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_8fragment_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_5query_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_8fragment_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL_5query_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 75, 0, __PYX_ERR(1, 75, __pyx_L1_error));
 
   /* "url/url.pyx":76
- *             return self.ptr.fragment()
+ *             return self.ptr.query()
  *         def __set__(self, s):
- *             self.ptr.setFragment(s)             # <<<<<<<<<<<<<<
+ *             self.ptr.setQuery(as_bytes(s))             # <<<<<<<<<<<<<<
  * 
- *     property userinfo:
+ *     property fragment:
  */
   __Pyx_TraceLine(76,0,__PYX_ERR(1, 76, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 76, __pyx_L1_error)
-  __pyx_v_self->ptr->setFragment(__pyx_t_1);
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 76, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 76, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setQuery(__pyx_t_2);
 
   /* "url/url.pyx":75
  *         def __get__(self):
- *             return self.ptr.fragment()
+ *             return self.ptr.query()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setFragment(s)
+ *             self.ptr.setQuery(as_bytes(s))
  * 
  */
 
@@ -2858,7 +2906,8 @@ static int __pyx_pf_3url_3url_3URL_8fragment_2__set__(struct __pyx_obj_3url_3url
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.fragment.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.query.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2868,26 +2917,26 @@ static int __pyx_pf_3url_3url_3URL_8fragment_2__set__(struct __pyx_obj_3url_3url
 
 /* "url/url.pyx":79
  * 
- *     property userinfo:
+ *     property fragment:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.userinfo()
+ *             return self.ptr.fragment()
  *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_8userinfo_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_8userinfo_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_8fragment_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_8fragment_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_8userinfo___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8fragment___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_8userinfo___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_8fragment___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -2896,15 +2945,15 @@ static PyObject *__pyx_pf_3url_3url_3URL_8userinfo___get__(struct __pyx_obj_3url
   __Pyx_TraceCall("__get__", __pyx_f[1], 79, 0, __PYX_ERR(1, 79, __pyx_L1_error));
 
   /* "url/url.pyx":80
- *     property userinfo:
+ *     property fragment:
  *         def __get__(self):
- *             return self.ptr.userinfo()             # <<<<<<<<<<<<<<
+ *             return self.ptr.fragment()             # <<<<<<<<<<<<<<
  *         def __set__(self, s):
- *             self.ptr.setUserinfo(s)
+ *             self.ptr.setFragment(as_bytes(s))
  */
   __Pyx_TraceLine(80,0,__PYX_ERR(1, 80, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->userinfo()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 80, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->fragment()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 80, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -2912,16 +2961,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_8userinfo___get__(struct __pyx_obj_3url
 
   /* "url/url.pyx":79
  * 
- *     property userinfo:
+ *     property fragment:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.userinfo()
+ *             return self.ptr.fragment()
  *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.userinfo.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.fragment.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -2932,49 +2981,53 @@ static PyObject *__pyx_pf_3url_3url_3URL_8userinfo___get__(struct __pyx_obj_3url
 
 /* "url/url.pyx":81
  *         def __get__(self):
- *             return self.ptr.userinfo()
+ *             return self.ptr.fragment()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setUserinfo(s)
+ *             self.ptr.setFragment(as_bytes(s))
  * 
  */
 
 /* Python wrapper */
-static int __pyx_pw_3url_3url_3URL_8userinfo_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
-static int __pyx_pw_3url_3url_3URL_8userinfo_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pw_3url_3url_9StringURL_8fragment_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_8fragment_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_8userinfo_2__set__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8fragment_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static int __pyx_pf_3url_3url_3URL_8userinfo_2__set__(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_s) {
+static int __pyx_pf_3url_3url_9StringURL_8fragment_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
   int __pyx_r;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  std::string __pyx_t_1;
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
   __Pyx_RefNannySetupContext("__set__", 0);
   __Pyx_TraceCall("__set__", __pyx_f[1], 81, 0, __PYX_ERR(1, 81, __pyx_L1_error));
 
   /* "url/url.pyx":82
- *             return self.ptr.userinfo()
+ *             return self.ptr.fragment()
  *         def __set__(self, s):
- *             self.ptr.setUserinfo(s)             # <<<<<<<<<<<<<<
+ *             self.ptr.setFragment(as_bytes(s))             # <<<<<<<<<<<<<<
  * 
- *     def copy(self):
+ *     property userinfo:
  */
   __Pyx_TraceLine(82,0,__PYX_ERR(1, 82, __pyx_L1_error))
-  __pyx_t_1 = __pyx_convert_string_from_py_std__in_string(__pyx_v_s); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 82, __pyx_L1_error)
-  __pyx_v_self->ptr->setUserinfo(__pyx_t_1);
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 82, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 82, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setFragment(__pyx_t_2);
 
   /* "url/url.pyx":81
  *         def __get__(self):
- *             return self.ptr.userinfo()
+ *             return self.ptr.fragment()
  *         def __set__(self, s):             # <<<<<<<<<<<<<<
- *             self.ptr.setUserinfo(s)
+ *             self.ptr.setFragment(as_bytes(s))
  * 
  */
 
@@ -2982,7 +3035,8 @@ static int __pyx_pf_3url_3url_3URL_8userinfo_2__set__(struct __pyx_obj_3url_3url
   __pyx_r = 0;
   goto __pyx_L0;
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.userinfo.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.fragment.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = -1;
   __pyx_L0:;
   __Pyx_TraceReturn(Py_None, 0);
@@ -2990,85 +3044,214 @@ static int __pyx_pf_3url_3url_3URL_8userinfo_2__set__(struct __pyx_obj_3url_3url
   return __pyx_r;
 }
 
-/* "url/url.pyx":84
- *             self.ptr.setUserinfo(s)
+/* "url/url.pyx":85
  * 
- *     def copy(self):             # <<<<<<<<<<<<<<
- *         '''Return a new instance of an identical URL.'''
- *         new = URL('')
+ *     property userinfo:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return self.ptr.userinfo()
+ *         def __set__(self, s):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_5copy(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_4copy[] = "Return a new instance of an identical URL.";
-static PyObject *__pyx_pw_3url_3url_3URL_5copy(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_8userinfo_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_8userinfo_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("copy (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4copy(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8userinfo___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_4copy(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
-  struct __pyx_obj_3url_3url_URL *__pyx_v_new = NULL;
+static PyObject *__pyx_pf_3url_3url_9StringURL_8userinfo___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
-  __Pyx_RefNannySetupContext("copy", 0);
-  __Pyx_TraceCall("copy", __pyx_f[1], 84, 0, __PYX_ERR(1, 84, __pyx_L1_error));
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 85, 0, __PYX_ERR(1, 85, __pyx_L1_error));
 
   /* "url/url.pyx":86
- *     def copy(self):
- *         '''Return a new instance of an identical URL.'''
- *         new = URL('')             # <<<<<<<<<<<<<<
- *         new.ptr.assign(dereference(self.ptr));
- *         return new
+ *     property userinfo:
+ *         def __get__(self):
+ *             return self.ptr.userinfo()             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setUserinfo(as_bytes(s))
  */
   __Pyx_TraceLine(86,0,__PYX_ERR(1, 86, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_3url_3url_URL), __pyx_tuple__6, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 86, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_v_new = ((struct __pyx_obj_3url_3url_URL *)__pyx_t_1);
-  __pyx_t_1 = 0;
-
-  /* "url/url.pyx":87
- *         '''Return a new instance of an identical URL.'''
- *         new = URL('')
- *         new.ptr.assign(dereference(self.ptr));             # <<<<<<<<<<<<<<
- *         return new
- * 
- */
-  __Pyx_TraceLine(87,0,__PYX_ERR(1, 87, __pyx_L1_error))
-  __pyx_v_new->ptr->assign((*__pyx_v_self->ptr));
-
-  /* "url/url.pyx":88
- *         new = URL('')
- *         new.ptr.assign(dereference(self.ptr));
- *         return new             # <<<<<<<<<<<<<<
- * 
- *     def equiv(self, other, encoding='utf-8'):
- */
-  __Pyx_TraceLine(88,0,__PYX_ERR(1, 88, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(((PyObject *)__pyx_v_new));
-  __pyx_r = ((PyObject *)__pyx_v_new);
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->userinfo()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 86, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "url/url.pyx":84
- *             self.ptr.setUserinfo(s)
+  /* "url/url.pyx":85
  * 
- *     def copy(self):             # <<<<<<<<<<<<<<
- *         '''Return a new instance of an identical URL.'''
- *         new = URL('')
+ *     property userinfo:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return self.ptr.userinfo()
+ *         def __set__(self, s):
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.copy", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.userinfo.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":87
+ *         def __get__(self):
+ *             return self.ptr.userinfo()
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setUserinfo(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_9StringURL_8userinfo_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_9StringURL_8userinfo_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8userinfo_2__set__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_9StringURL_8userinfo_2__set__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 87, 0, __PYX_ERR(1, 87, __pyx_L1_error));
+
+  /* "url/url.pyx":88
+ *             return self.ptr.userinfo()
+ *         def __set__(self, s):
+ *             self.ptr.setUserinfo(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     def copy(self):
+ */
+  __Pyx_TraceLine(88,0,__PYX_ERR(1, 88, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 88, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 88, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->ptr->setUserinfo(__pyx_t_2);
+
+  /* "url/url.pyx":87
+ *         def __get__(self):
+ *             return self.ptr.userinfo()
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setUserinfo(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.userinfo.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":90
+ *             self.ptr.setUserinfo(as_bytes(s))
+ * 
+ *     def copy(self):             # <<<<<<<<<<<<<<
+ *         '''Return a new instance of an identical URL.'''
+ *         new = StringURL(b'')
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_5copy(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_4copy[] = "Return a new instance of an identical URL.";
+static PyObject *__pyx_pw_3url_3url_9StringURL_5copy(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("copy (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4copy(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_9StringURL_4copy(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  struct __pyx_obj_3url_3url_StringURL *__pyx_v_new = NULL;
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("copy", 0);
+  __Pyx_TraceCall("copy", __pyx_f[1], 90, 0, __PYX_ERR(1, 90, __pyx_L1_error));
+
+  /* "url/url.pyx":92
+ *     def copy(self):
+ *         '''Return a new instance of an identical URL.'''
+ *         new = StringURL(b'')             # <<<<<<<<<<<<<<
+ *         new.ptr.assign(dereference(self.ptr));
+ *         return new
+ */
+  __Pyx_TraceLine(92,0,__PYX_ERR(1, 92, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyObject_Call(((PyObject *)__pyx_ptype_3url_3url_StringURL), __pyx_tuple__7, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 92, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_v_new = ((struct __pyx_obj_3url_3url_StringURL *)__pyx_t_1);
+  __pyx_t_1 = 0;
+
+  /* "url/url.pyx":93
+ *         '''Return a new instance of an identical URL.'''
+ *         new = StringURL(b'')
+ *         new.ptr.assign(dereference(self.ptr));             # <<<<<<<<<<<<<<
+ *         return new
+ * 
+ */
+  __Pyx_TraceLine(93,0,__PYX_ERR(1, 93, __pyx_L1_error))
+  __pyx_v_new->ptr->assign((*__pyx_v_self->ptr));
+
+  /* "url/url.pyx":94
+ *         new = StringURL(b'')
+ *         new.ptr.assign(dereference(self.ptr));
+ *         return new             # <<<<<<<<<<<<<<
+ * 
+ *     def equiv(self, other, encoding='utf-8'):
+ */
+  __Pyx_TraceLine(94,0,__PYX_ERR(1, 94, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(((PyObject *)__pyx_v_new));
+  __pyx_r = ((PyObject *)__pyx_v_new);
+  goto __pyx_L0;
+
+  /* "url/url.pyx":90
+ *             self.ptr.setUserinfo(as_bytes(s))
+ * 
+ *     def copy(self):             # <<<<<<<<<<<<<<
+ *         '''Return a new instance of an identical URL.'''
+ *         new = StringURL(b'')
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.copy", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XDECREF((PyObject *)__pyx_v_new);
@@ -3078,7 +3261,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_4copy(struct __pyx_obj_3url_3url_URL *_
   return __pyx_r;
 }
 
-/* "url/url.pyx":90
+/* "url/url.pyx":96
  *         return new
  * 
  *     def equiv(self, other, encoding='utf-8'):             # <<<<<<<<<<<<<<
@@ -3087,9 +3270,9 @@ static PyObject *__pyx_pf_3url_3url_3URL_4copy(struct __pyx_obj_3url_3url_URL *_
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_7equiv(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_3url_3url_3URL_6equiv[] = "Return true if this url is equivalent to another";
-static PyObject *__pyx_pw_3url_3url_3URL_7equiv(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_7equiv(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_6equiv[] = "Return true if this url is equivalent to another";
+static PyObject *__pyx_pw_3url_3url_9StringURL_7equiv(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_other = 0;
   PyObject *__pyx_v_encoding = 0;
   PyObject *__pyx_r = 0;
@@ -3120,7 +3303,7 @@ static PyObject *__pyx_pw_3url_3url_3URL_7equiv(PyObject *__pyx_v_self, PyObject
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "equiv") < 0)) __PYX_ERR(1, 90, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "equiv") < 0)) __PYX_ERR(1, 96, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -3135,20 +3318,20 @@ static PyObject *__pyx_pw_3url_3url_3URL_7equiv(PyObject *__pyx_v_self, PyObject
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("equiv", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 90, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("equiv", 0, 1, 2, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 96, __pyx_L3_error)
   __pyx_L3_error:;
-  __Pyx_AddTraceback("url.url.URL.equiv", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.equiv", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_3url_3url_3URL_6equiv(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), __pyx_v_other, __pyx_v_encoding);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_6equiv(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), __pyx_v_other, __pyx_v_encoding);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_encoding) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_6equiv(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_encoding) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -3162,32 +3345,32 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
   Py_ssize_t __pyx_t_8;
   PyObject *__pyx_t_9 = NULL;
   __Pyx_RefNannySetupContext("equiv", 0);
-  __Pyx_TraceCall("equiv", __pyx_f[1], 90, 0, __PYX_ERR(1, 90, __pyx_L1_error));
+  __Pyx_TraceCall("equiv", __pyx_f[1], 96, 0, __PYX_ERR(1, 96, __pyx_L1_error));
 
-  /* "url/url.pyx":92
+  /* "url/url.pyx":98
  *     def equiv(self, other, encoding='utf-8'):
  *         '''Return true if this url is equivalent to another'''
  *         if isinstance(other, basestring):             # <<<<<<<<<<<<<<
  *             return self.equiv(self.parse(other, encoding))
- *         return self.ptr.equiv(dereference((<URL?>other).ptr))
+ *         return self.ptr.equiv(dereference((<StringURL?>other).ptr))
  */
-  __Pyx_TraceLine(92,0,__PYX_ERR(1, 92, __pyx_L1_error))
+  __Pyx_TraceLine(98,0,__PYX_ERR(1, 98, __pyx_L1_error))
   __pyx_t_1 = __Pyx_PyBaseString_Check(__pyx_v_other); 
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "url/url.pyx":93
+    /* "url/url.pyx":99
  *         '''Return true if this url is equivalent to another'''
  *         if isinstance(other, basestring):
  *             return self.equiv(self.parse(other, encoding))             # <<<<<<<<<<<<<<
- *         return self.ptr.equiv(dereference((<URL?>other).ptr))
+ *         return self.ptr.equiv(dereference((<StringURL?>other).ptr))
  * 
  */
-    __Pyx_TraceLine(93,0,__PYX_ERR(1, 93, __pyx_L1_error))
+    __Pyx_TraceLine(99,0,__PYX_ERR(1, 99, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_equiv); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 93, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_equiv); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 99, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_parse); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 93, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_parse); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 99, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_t_7 = NULL;
     __pyx_t_8 = 0;
@@ -3201,7 +3384,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
         __pyx_t_8 = 1;
       }
     }
-    __pyx_t_9 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 93, __pyx_L1_error)
+    __pyx_t_9 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 99, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     if (__pyx_t_7) {
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -3212,7 +3395,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
     __Pyx_INCREF(__pyx_v_encoding);
     __Pyx_GIVEREF(__pyx_v_encoding);
     PyTuple_SET_ITEM(__pyx_t_9, 1+__pyx_t_8, __pyx_v_encoding);
-    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_9, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 93, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_9, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 99, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -3227,17 +3410,17 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
       }
     }
     if (!__pyx_t_6) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 93, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 99, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_9 = PyTuple_New(1+1); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 93, __pyx_L1_error)
+      __pyx_t_9 = PyTuple_New(1+1); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 99, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_9);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_GIVEREF(__pyx_t_5);
       PyTuple_SET_ITEM(__pyx_t_9, 0+1, __pyx_t_5);
       __pyx_t_5 = 0;
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_9, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 93, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_9, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 99, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     }
@@ -3246,32 +3429,32 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":92
+    /* "url/url.pyx":98
  *     def equiv(self, other, encoding='utf-8'):
  *         '''Return true if this url is equivalent to another'''
  *         if isinstance(other, basestring):             # <<<<<<<<<<<<<<
  *             return self.equiv(self.parse(other, encoding))
- *         return self.ptr.equiv(dereference((<URL?>other).ptr))
+ *         return self.ptr.equiv(dereference((<StringURL?>other).ptr))
  */
   }
 
-  /* "url/url.pyx":94
+  /* "url/url.pyx":100
  *         if isinstance(other, basestring):
  *             return self.equiv(self.parse(other, encoding))
- *         return self.ptr.equiv(dereference((<URL?>other).ptr))             # <<<<<<<<<<<<<<
+ *         return self.ptr.equiv(dereference((<StringURL?>other).ptr))             # <<<<<<<<<<<<<<
  * 
  *     def __richcmp__(self, other, op):
  */
-  __Pyx_TraceLine(94,0,__PYX_ERR(1, 94, __pyx_L1_error))
+  __Pyx_TraceLine(100,0,__PYX_ERR(1, 100, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  if (!(likely(__Pyx_TypeTest(__pyx_v_other, __pyx_ptype_3url_3url_URL)))) __PYX_ERR(1, 94, __pyx_L1_error)
-  __pyx_t_3 = __Pyx_PyBool_FromLong(__pyx_v_self->ptr->equiv((*((struct __pyx_obj_3url_3url_URL *)__pyx_v_other)->ptr))); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 94, __pyx_L1_error)
+  if (!(likely(__Pyx_TypeTest(__pyx_v_other, __pyx_ptype_3url_3url_StringURL)))) __PYX_ERR(1, 100, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyBool_FromLong(__pyx_v_self->ptr->equiv((*((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_other)->ptr))); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 100, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_r = __pyx_t_3;
   __pyx_t_3 = 0;
   goto __pyx_L0;
 
-  /* "url/url.pyx":90
+  /* "url/url.pyx":96
  *         return new
  * 
  *     def equiv(self, other, encoding='utf-8'):             # <<<<<<<<<<<<<<
@@ -3287,7 +3470,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
   __Pyx_XDECREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_7);
   __Pyx_XDECREF(__pyx_t_9);
-  __Pyx_AddTraceback("url.url.URL.equiv", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.equiv", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -3296,8 +3479,8 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
   return __pyx_r;
 }
 
-/* "url/url.pyx":96
- *         return self.ptr.equiv(dereference((<URL?>other).ptr))
+/* "url/url.pyx":102
+ *         return self.ptr.equiv(dereference((<StringURL?>other).ptr))
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
  *         '''Return true if this url is /exactly/ equal to another'''
@@ -3305,21 +3488,21 @@ static PyObject *__pyx_pf_3url_3url_3URL_6equiv(struct __pyx_obj_3url_3url_URL *
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_9__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, int __pyx_arg_op); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_9__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, int __pyx_arg_op) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_9__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, int __pyx_arg_op); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_9__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, int __pyx_arg_op) {
   PyObject *__pyx_v_op = 0;
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__richcmp__ (wrapper)", 0);
-  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(1, 96, __pyx_L3_error)
+  __pyx_v_op = __Pyx_PyInt_From_int(__pyx_arg_op); if (unlikely(!__pyx_v_op)) __PYX_ERR(1, 102, __pyx_L3_error)
   __Pyx_GOTREF(__pyx_v_op);
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L3_error:;
-  __Pyx_AddTraceback("url.url.URL.__richcmp__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.__richcmp__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_3url_3url_3URL_8__richcmp__(((PyObject *)__pyx_v_self), ((PyObject *)__pyx_v_other), ((PyObject *)__pyx_v_op));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8__richcmp__(((PyObject *)__pyx_v_self), ((PyObject *)__pyx_v_other), ((PyObject *)__pyx_v_op));
 
   /* function exit code */
   __Pyx_XDECREF(__pyx_v_op);
@@ -3327,7 +3510,7 @@ static PyObject *__pyx_pw_3url_3url_3URL_9__richcmp__(PyObject *__pyx_v_self, Py
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_op) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_8__richcmp__(PyObject *__pyx_v_self, PyObject *__pyx_v_other, PyObject *__pyx_v_op) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -3341,46 +3524,46 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
   Py_ssize_t __pyx_t_8;
   PyObject *__pyx_t_9 = NULL;
   __Pyx_RefNannySetupContext("__richcmp__", 0);
-  __Pyx_TraceCall("__richcmp__", __pyx_f[1], 96, 0, __PYX_ERR(1, 96, __pyx_L1_error));
+  __Pyx_TraceCall("__richcmp__", __pyx_f[1], 102, 0, __PYX_ERR(1, 102, __pyx_L1_error));
 
-  /* "url/url.pyx":98
+  /* "url/url.pyx":104
  *     def __richcmp__(self, other, op):
  *         '''Return true if this url is /exactly/ equal to another'''
  *         if op == 2:  # ==             # <<<<<<<<<<<<<<
  *             if isinstance(other, basestring):
  *                 return self.__eq__(self.parse(other, 'utf-8'))
  */
-  __Pyx_TraceLine(98,0,__PYX_ERR(1, 98, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 98, __pyx_L1_error)
+  __Pyx_TraceLine(104,0,__PYX_ERR(1, 104, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_2, 2, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 104, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 98, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 104, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_2) {
 
-    /* "url/url.pyx":99
+    /* "url/url.pyx":105
  *         '''Return true if this url is /exactly/ equal to another'''
  *         if op == 2:  # ==
  *             if isinstance(other, basestring):             # <<<<<<<<<<<<<<
  *                 return self.__eq__(self.parse(other, 'utf-8'))
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
  */
-    __Pyx_TraceLine(99,0,__PYX_ERR(1, 99, __pyx_L1_error))
+    __Pyx_TraceLine(105,0,__PYX_ERR(1, 105, __pyx_L1_error))
     __pyx_t_2 = __Pyx_PyBaseString_Check(__pyx_v_other); 
     __pyx_t_3 = (__pyx_t_2 != 0);
     if (__pyx_t_3) {
 
-      /* "url/url.pyx":100
+      /* "url/url.pyx":106
  *         if op == 2:  # ==
  *             if isinstance(other, basestring):
  *                 return self.__eq__(self.parse(other, 'utf-8'))             # <<<<<<<<<<<<<<
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
  *         elif op == 3:  # !=
  */
-      __Pyx_TraceLine(100,0,__PYX_ERR(1, 100, __pyx_L1_error))
+      __Pyx_TraceLine(106,0,__PYX_ERR(1, 106, __pyx_L1_error))
       __Pyx_XDECREF(__pyx_r);
-      __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_eq); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 100, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_eq); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 106, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
-      __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_parse); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 100, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_parse); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 106, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __pyx_t_7 = NULL;
       __pyx_t_8 = 0;
@@ -3394,7 +3577,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
           __pyx_t_8 = 1;
         }
       }
-      __pyx_t_9 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 100, __pyx_L1_error)
+      __pyx_t_9 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 106, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_9);
       if (__pyx_t_7) {
         __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -3405,7 +3588,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
       __Pyx_INCREF(__pyx_kp_s_utf_8);
       __Pyx_GIVEREF(__pyx_kp_s_utf_8);
       PyTuple_SET_ITEM(__pyx_t_9, 1+__pyx_t_8, __pyx_kp_s_utf_8);
-      __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_9, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 100, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_9, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 106, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -3420,17 +3603,17 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
         }
       }
       if (!__pyx_t_6) {
-        __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 100, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 106, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
         __Pyx_GOTREF(__pyx_t_1);
       } else {
-        __pyx_t_9 = PyTuple_New(1+1); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 100, __pyx_L1_error)
+        __pyx_t_9 = PyTuple_New(1+1); if (unlikely(!__pyx_t_9)) __PYX_ERR(1, 106, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_9);
         __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_6); __pyx_t_6 = NULL;
         __Pyx_GIVEREF(__pyx_t_5);
         PyTuple_SET_ITEM(__pyx_t_9, 0+1, __pyx_t_5);
         __pyx_t_5 = 0;
-        __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_9, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 100, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_9, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 106, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
       }
@@ -3439,32 +3622,32 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
       __pyx_t_1 = 0;
       goto __pyx_L0;
 
-      /* "url/url.pyx":99
+      /* "url/url.pyx":105
  *         '''Return true if this url is /exactly/ equal to another'''
  *         if op == 2:  # ==
  *             if isinstance(other, basestring):             # <<<<<<<<<<<<<<
  *                 return self.__eq__(self.parse(other, 'utf-8'))
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
  */
     }
 
-    /* "url/url.pyx":101
+    /* "url/url.pyx":107
  *             if isinstance(other, basestring):
  *                 return self.__eq__(self.parse(other, 'utf-8'))
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)             # <<<<<<<<<<<<<<
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)             # <<<<<<<<<<<<<<
  *         elif op == 3:  # !=
  *             return not (self == other)
  */
-    __Pyx_TraceLine(101,0,__PYX_ERR(1, 101, __pyx_L1_error))
+    __Pyx_TraceLine(107,0,__PYX_ERR(1, 107, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    if (!(likely(__Pyx_TypeTest(__pyx_v_other, __pyx_ptype_3url_3url_URL)))) __PYX_ERR(1, 101, __pyx_L1_error)
-    __pyx_t_1 = __Pyx_PyBool_FromLong(((*((struct __pyx_obj_3url_3url_URL *)__pyx_v_self)->ptr) == (*((struct __pyx_obj_3url_3url_URL *)__pyx_v_other)->ptr))); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 101, __pyx_L1_error)
+    if (!(likely(__Pyx_TypeTest(__pyx_v_other, __pyx_ptype_3url_3url_StringURL)))) __PYX_ERR(1, 107, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyBool_FromLong(((*((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self)->ptr) == (*((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_other)->ptr))); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 107, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_r = __pyx_t_1;
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":98
+    /* "url/url.pyx":104
  *     def __richcmp__(self, other, op):
  *         '''Return true if this url is /exactly/ equal to another'''
  *         if op == 2:  # ==             # <<<<<<<<<<<<<<
@@ -3473,94 +3656,94 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
  */
   }
 
-  /* "url/url.pyx":102
+  /* "url/url.pyx":108
  *                 return self.__eq__(self.parse(other, 'utf-8'))
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
  *             return not (self == other)
  *         else:
  */
-  __Pyx_TraceLine(102,0,__PYX_ERR(1, 102, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 102, __pyx_L1_error)
+  __Pyx_TraceLine(108,0,__PYX_ERR(1, 108, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyInt_EqObjC(__pyx_v_op, __pyx_int_3, 3, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 108, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(1, 102, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(1, 108, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (__pyx_t_3) {
 
-    /* "url/url.pyx":103
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+    /* "url/url.pyx":109
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
  *         elif op == 3:  # !=
  *             return not (self == other)             # <<<<<<<<<<<<<<
  *         else:
  *             raise NotImplementedError(
  */
-    __Pyx_TraceLine(103,0,__PYX_ERR(1, 103, __pyx_L1_error))
+    __Pyx_TraceLine(109,0,__PYX_ERR(1, 109, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_1 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 103, __pyx_L1_error)
-    __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(1, 103, __pyx_L1_error)
+    __pyx_t_1 = PyObject_RichCompare(__pyx_v_self, __pyx_v_other, Py_EQ); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 109, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_3 < 0)) __PYX_ERR(1, 109, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_1 = __Pyx_PyBool_FromLong((!__pyx_t_3)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 103, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyBool_FromLong((!__pyx_t_3)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 109, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_r = __pyx_t_1;
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":102
+    /* "url/url.pyx":108
  *                 return self.__eq__(self.parse(other, 'utf-8'))
- *             return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+ *             return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
  *         elif op == 3:  # !=             # <<<<<<<<<<<<<<
  *             return not (self == other)
  *         else:
  */
   }
 
-  /* "url/url.pyx":105
+  /* "url/url.pyx":111
  *             return not (self == other)
  *         else:
  *             raise NotImplementedError(             # <<<<<<<<<<<<<<
  *                 '%s does not support this operation.' % type(self).__name__)
  * 
  */
-  __Pyx_TraceLine(105,0,__PYX_ERR(1, 105, __pyx_L1_error))
+  __Pyx_TraceLine(111,0,__PYX_ERR(1, 111, __pyx_L1_error))
   /*else*/ {
 
-    /* "url/url.pyx":106
+    /* "url/url.pyx":112
  *         else:
  *             raise NotImplementedError(
  *                 '%s does not support this operation.' % type(self).__name__)             # <<<<<<<<<<<<<<
  * 
- *     def __str__(self):
+ *     def __unicode__(self):
  */
-    __Pyx_TraceLine(106,0,__PYX_ERR(1, 106, __pyx_L1_error))
-    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)Py_TYPE(__pyx_v_self)), __pyx_n_s_name); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 106, __pyx_L1_error)
+    __Pyx_TraceLine(112,0,__PYX_ERR(1, 112, __pyx_L1_error))
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)Py_TYPE(__pyx_v_self)), __pyx_n_s_name); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 112, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_4 = __Pyx_PyString_Format(__pyx_kp_s_s_does_not_support_this_operati, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 106, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyString_Format(__pyx_kp_s_s_does_not_support_this_operati, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 112, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "url/url.pyx":105
+    /* "url/url.pyx":111
  *             return not (self == other)
  *         else:
  *             raise NotImplementedError(             # <<<<<<<<<<<<<<
  *                 '%s does not support this operation.' % type(self).__name__)
  * 
  */
-    __Pyx_TraceLine(105,0,__PYX_ERR(1, 105, __pyx_L1_error))
-    __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 105, __pyx_L1_error)
+    __Pyx_TraceLine(111,0,__PYX_ERR(1, 111, __pyx_L1_error))
+    __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 111, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_GIVEREF(__pyx_t_4);
     PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_4);
     __pyx_t_4 = 0;
-    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_NotImplementedError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 105, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_NotImplementedError, __pyx_t_1, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 111, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_Raise(__pyx_t_4, 0, 0, 0);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __PYX_ERR(1, 105, __pyx_L1_error)
+    __PYX_ERR(1, 111, __pyx_L1_error)
   }
 
-  /* "url/url.pyx":96
- *         return self.ptr.equiv(dereference((<URL?>other).ptr))
+  /* "url/url.pyx":102
+ *         return self.ptr.equiv(dereference((<StringURL?>other).ptr))
  * 
  *     def __richcmp__(self, other, op):             # <<<<<<<<<<<<<<
  *         '''Return true if this url is /exactly/ equal to another'''
@@ -3575,140 +3758,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_8__richcmp__(PyObject *__pyx_v_self, Py
   __Pyx_XDECREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_7);
   __Pyx_XDECREF(__pyx_t_9);
-  __Pyx_AddTraceback("url.url.URL.__richcmp__", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_r = NULL;
-  __pyx_L0:;
-  __Pyx_XGIVEREF(__pyx_r);
-  __Pyx_TraceReturn(__pyx_r, 0);
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-/* "url/url.pyx":108
- *                 '%s does not support this operation.' % type(self).__name__)
- * 
- *     def __str__(self):             # <<<<<<<<<<<<<<
- *         return self.utf8
- * 
- */
-
-/* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_11__str__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_11__str__(PyObject *__pyx_v_self) {
-  PyObject *__pyx_r = 0;
-  __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("__str__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_10__str__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
-
-  /* function exit code */
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-static PyObject *__pyx_pf_3url_3url_3URL_10__str__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
-  PyObject *__pyx_r = NULL;
-  __Pyx_TraceDeclarations
-  __Pyx_RefNannyDeclarations
-  PyObject *__pyx_t_1 = NULL;
-  __Pyx_RefNannySetupContext("__str__", 0);
-  __Pyx_TraceCall("__str__", __pyx_f[1], 108, 0, __PYX_ERR(1, 108, __pyx_L1_error));
-
-  /* "url/url.pyx":109
- * 
- *     def __str__(self):
- *         return self.utf8             # <<<<<<<<<<<<<<
- * 
- *     def __repr__(self):
- */
-  __Pyx_TraceLine(109,0,__PYX_ERR(1, 109, __pyx_L1_error))
-  __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_utf8); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 109, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_r = __pyx_t_1;
-  __pyx_t_1 = 0;
-  goto __pyx_L0;
-
-  /* "url/url.pyx":108
- *                 '%s does not support this operation.' % type(self).__name__)
- * 
- *     def __str__(self):             # <<<<<<<<<<<<<<
- *         return self.utf8
- * 
- */
-
-  /* function exit code */
-  __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.__str__", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_r = NULL;
-  __pyx_L0:;
-  __Pyx_XGIVEREF(__pyx_r);
-  __Pyx_TraceReturn(__pyx_r, 0);
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-/* "url/url.pyx":111
- *         return self.utf8
- * 
- *     def __repr__(self):             # <<<<<<<<<<<<<<
- *         return '<url.URL object "%s" >' % self.utf8
- * 
- */
-
-/* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_13__repr__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_13__repr__(PyObject *__pyx_v_self) {
-  PyObject *__pyx_r = 0;
-  __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("__repr__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_12__repr__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
-
-  /* function exit code */
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-static PyObject *__pyx_pf_3url_3url_3URL_12__repr__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
-  PyObject *__pyx_r = NULL;
-  __Pyx_TraceDeclarations
-  __Pyx_RefNannyDeclarations
-  PyObject *__pyx_t_1 = NULL;
-  PyObject *__pyx_t_2 = NULL;
-  __Pyx_RefNannySetupContext("__repr__", 0);
-  __Pyx_TraceCall("__repr__", __pyx_f[1], 111, 0, __PYX_ERR(1, 111, __pyx_L1_error));
-
-  /* "url/url.pyx":112
- * 
- *     def __repr__(self):
- *         return '<url.URL object "%s" >' % self.utf8             # <<<<<<<<<<<<<<
- * 
- *     def canonical(self):
- */
-  __Pyx_TraceLine(112,0,__PYX_ERR(1, 112, __pyx_L1_error))
-  __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_utf8); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 112, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyString_Format(__pyx_kp_s_url_URL_object_s, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 112, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_2);
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_r = __pyx_t_2;
-  __pyx_t_2 = 0;
-  goto __pyx_L0;
-
-  /* "url/url.pyx":111
- *         return self.utf8
- * 
- *     def __repr__(self):             # <<<<<<<<<<<<<<
- *         return '<url.URL object "%s" >' % self.utf8
- * 
- */
-
-  /* function exit code */
-  __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_XDECREF(__pyx_t_2);
-  __Pyx_AddTraceback("url.url.URL.__repr__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.__richcmp__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -3718,67 +3768,61 @@ static PyObject *__pyx_pf_3url_3url_3URL_12__repr__(struct __pyx_obj_3url_3url_U
 }
 
 /* "url/url.pyx":114
- *         return '<url.URL object "%s" >' % self.utf8
+ *                 '%s does not support this operation.' % type(self).__name__)
  * 
- *     def canonical(self):             # <<<<<<<<<<<<<<
- *         self.ptr.sort_query()
- *         return self
+ *     def __unicode__(self):             # <<<<<<<<<<<<<<
+ *         return self.unicode
+ * 
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_15canonical(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_15canonical(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_11__unicode__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_11__unicode__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("canonical (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_14canonical(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __Pyx_RefNannySetupContext("__unicode__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_10__unicode__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_14canonical(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_10__unicode__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("canonical", 0);
-  __Pyx_TraceCall("canonical", __pyx_f[1], 114, 0, __PYX_ERR(1, 114, __pyx_L1_error));
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("__unicode__", 0);
+  __Pyx_TraceCall("__unicode__", __pyx_f[1], 114, 0, __PYX_ERR(1, 114, __pyx_L1_error));
 
   /* "url/url.pyx":115
  * 
- *     def canonical(self):
- *         self.ptr.sort_query()             # <<<<<<<<<<<<<<
- *         return self
+ *     def __unicode__(self):
+ *         return self.unicode             # <<<<<<<<<<<<<<
  * 
+ *     def __str__(self):
  */
   __Pyx_TraceLine(115,0,__PYX_ERR(1, 115, __pyx_L1_error))
-  __pyx_v_self->ptr->sort_query();
-
-  /* "url/url.pyx":116
- *     def canonical(self):
- *         self.ptr.sort_query()
- *         return self             # <<<<<<<<<<<<<<
- * 
- *     def defrag(self):
- */
-  __Pyx_TraceLine(116,0,__PYX_ERR(1, 116, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(((PyObject *)__pyx_v_self));
-  __pyx_r = ((PyObject *)__pyx_v_self);
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_unicode); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 115, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
   goto __pyx_L0;
 
   /* "url/url.pyx":114
- *         return '<url.URL object "%s" >' % self.utf8
+ *                 '%s does not support this operation.' % type(self).__name__)
  * 
- *     def canonical(self):             # <<<<<<<<<<<<<<
- *         self.ptr.sort_query()
- *         return self
+ *     def __unicode__(self):             # <<<<<<<<<<<<<<
+ *         return self.unicode
+ * 
  */
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.canonical", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.__unicode__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -3787,69 +3831,126 @@ static PyObject *__pyx_pf_3url_3url_3URL_14canonical(struct __pyx_obj_3url_3url_
   return __pyx_r;
 }
 
-/* "url/url.pyx":118
- *         return self
+/* "url/url.pyx":117
+ *         return self.unicode
  * 
- *     def defrag(self):             # <<<<<<<<<<<<<<
- *         '''Remove the fragment from this url'''
- *         self.ptr.defrag()
+ *     def __str__(self):             # <<<<<<<<<<<<<<
+ *         return self.utf8
+ * 
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_17defrag(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_16defrag[] = "Remove the fragment from this url";
-static PyObject *__pyx_pw_3url_3url_3URL_17defrag(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_13__str__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_13__str__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("defrag (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_16defrag(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __Pyx_RefNannySetupContext("__str__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_12__str__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_16defrag(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_12__str__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("defrag", 0);
-  __Pyx_TraceCall("defrag", __pyx_f[1], 118, 0, __PYX_ERR(1, 118, __pyx_L1_error));
-
-  /* "url/url.pyx":120
- *     def defrag(self):
- *         '''Remove the fragment from this url'''
- *         self.ptr.defrag()             # <<<<<<<<<<<<<<
- *         return self
- * 
- */
-  __Pyx_TraceLine(120,0,__PYX_ERR(1, 120, __pyx_L1_error))
-  __pyx_v_self->ptr->defrag();
-
-  /* "url/url.pyx":121
- *         '''Remove the fragment from this url'''
- *         self.ptr.defrag()
- *         return self             # <<<<<<<<<<<<<<
- * 
- *     def deparam(self, params):
- */
-  __Pyx_TraceLine(121,0,__PYX_ERR(1, 121, __pyx_L1_error))
-  __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(((PyObject *)__pyx_v_self));
-  __pyx_r = ((PyObject *)__pyx_v_self);
-  goto __pyx_L0;
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("__str__", 0);
+  __Pyx_TraceCall("__str__", __pyx_f[1], 117, 0, __PYX_ERR(1, 117, __pyx_L1_error));
 
   /* "url/url.pyx":118
- *         return self
  * 
- *     def defrag(self):             # <<<<<<<<<<<<<<
- *         '''Remove the fragment from this url'''
- *         self.ptr.defrag()
+ *     def __str__(self):
+ *         return self.utf8             # <<<<<<<<<<<<<<
+ * 
+ *     def __bytes__(self):
+ */
+  __Pyx_TraceLine(118,0,__PYX_ERR(1, 118, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_utf8); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 118, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":117
+ *         return self.unicode
+ * 
+ *     def __str__(self):             # <<<<<<<<<<<<<<
+ *         return self.utf8
+ * 
  */
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.defrag", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.__str__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":120
+ *         return self.utf8
+ * 
+ *     def __bytes__(self):             # <<<<<<<<<<<<<<
+ *         return self.utf8
+ * 
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_15__bytes__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_15__bytes__(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__bytes__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_14__bytes__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_9StringURL_14__bytes__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("__bytes__", 0);
+  __Pyx_TraceCall("__bytes__", __pyx_f[1], 120, 0, __PYX_ERR(1, 120, __pyx_L1_error));
+
+  /* "url/url.pyx":121
+ * 
+ *     def __bytes__(self):
+ *         return self.utf8             # <<<<<<<<<<<<<<
+ * 
+ *     def __repr__(self):
+ */
+  __Pyx_TraceLine(121,0,__PYX_ERR(1, 121, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_utf8); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 121, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":120
+ *         return self.utf8
+ * 
+ *     def __bytes__(self):             # <<<<<<<<<<<<<<
+ *         return self.utf8
+ * 
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.__bytes__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -3859,37 +3960,253 @@ static PyObject *__pyx_pf_3url_3url_3URL_16defrag(struct __pyx_obj_3url_3url_URL
 }
 
 /* "url/url.pyx":123
- *         return self
+ *         return self.utf8
  * 
- *     def deparam(self, params):             # <<<<<<<<<<<<<<
- *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)
+ *     def __repr__(self):             # <<<<<<<<<<<<<<
+ *         return '<url.URL object "%s" >' % str(self)
+ * 
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_19deparam(PyObject *__pyx_v_self, PyObject *__pyx_v_params); /*proto*/
-static char __pyx_doc_3url_3url_3URL_18deparam[] = "Strip any of the provided parameters out of the url";
-static PyObject *__pyx_pw_3url_3url_3URL_19deparam(PyObject *__pyx_v_self, PyObject *__pyx_v_params) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_17__repr__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_17__repr__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("deparam (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_18deparam(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_params));
+  __Pyx_RefNannySetupContext("__repr__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_16__repr__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
-static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value); /* proto */
 
-/* "url/url.pyx":125
+static PyObject *__pyx_pf_3url_3url_9StringURL_16__repr__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  __Pyx_RefNannySetupContext("__repr__", 0);
+  __Pyx_TraceCall("__repr__", __pyx_f[1], 123, 0, __PYX_ERR(1, 123, __pyx_L1_error));
+
+  /* "url/url.pyx":124
+ * 
+ *     def __repr__(self):
+ *         return '<url.URL object "%s" >' % str(self)             # <<<<<<<<<<<<<<
+ * 
+ *     def canonical(self):
+ */
+  __Pyx_TraceLine(124,0,__PYX_ERR(1, 124, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = PyTuple_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 124, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __Pyx_INCREF(((PyObject *)__pyx_v_self));
+  __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
+  PyTuple_SET_ITEM(__pyx_t_1, 0, ((PyObject *)__pyx_v_self));
+  __pyx_t_2 = __Pyx_PyObject_Call(((PyObject *)(&PyString_Type)), __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 124, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_t_1 = __Pyx_PyString_Format(__pyx_kp_s_url_URL_object_s, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 124, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":123
+ *         return self.utf8
+ * 
+ *     def __repr__(self):             # <<<<<<<<<<<<<<
+ *         return '<url.URL object "%s" >' % str(self)
+ * 
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_AddTraceback("url.url.StringURL.__repr__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":126
+ *         return '<url.URL object "%s" >' % str(self)
+ * 
+ *     def canonical(self):             # <<<<<<<<<<<<<<
+ *         self.ptr.sort_query()
+ *         return self
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_19canonical(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_19canonical(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("canonical (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_18canonical(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_9StringURL_18canonical(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("canonical", 0);
+  __Pyx_TraceCall("canonical", __pyx_f[1], 126, 0, __PYX_ERR(1, 126, __pyx_L1_error));
+
+  /* "url/url.pyx":127
+ * 
+ *     def canonical(self):
+ *         self.ptr.sort_query()             # <<<<<<<<<<<<<<
+ *         return self
+ * 
+ */
+  __Pyx_TraceLine(127,0,__PYX_ERR(1, 127, __pyx_L1_error))
+  __pyx_v_self->ptr->sort_query();
+
+  /* "url/url.pyx":128
+ *     def canonical(self):
+ *         self.ptr.sort_query()
+ *         return self             # <<<<<<<<<<<<<<
+ * 
+ *     def defrag(self):
+ */
+  __Pyx_TraceLine(128,0,__PYX_ERR(1, 128, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(((PyObject *)__pyx_v_self));
+  __pyx_r = ((PyObject *)__pyx_v_self);
+  goto __pyx_L0;
+
+  /* "url/url.pyx":126
+ *         return '<url.URL object "%s" >' % str(self)
+ * 
+ *     def canonical(self):             # <<<<<<<<<<<<<<
+ *         self.ptr.sort_query()
+ *         return self
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_AddTraceback("url.url.StringURL.canonical", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":130
+ *         return self
+ * 
+ *     def defrag(self):             # <<<<<<<<<<<<<<
+ *         '''Remove the fragment from this url'''
+ *         self.ptr.defrag()
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_21defrag(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_20defrag[] = "Remove the fragment from this url";
+static PyObject *__pyx_pw_3url_3url_9StringURL_21defrag(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("defrag (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_20defrag(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_9StringURL_20defrag(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("defrag", 0);
+  __Pyx_TraceCall("defrag", __pyx_f[1], 130, 0, __PYX_ERR(1, 130, __pyx_L1_error));
+
+  /* "url/url.pyx":132
+ *     def defrag(self):
+ *         '''Remove the fragment from this url'''
+ *         self.ptr.defrag()             # <<<<<<<<<<<<<<
+ *         return self
+ * 
+ */
+  __Pyx_TraceLine(132,0,__PYX_ERR(1, 132, __pyx_L1_error))
+  __pyx_v_self->ptr->defrag();
+
+  /* "url/url.pyx":133
+ *         '''Remove the fragment from this url'''
+ *         self.ptr.defrag()
+ *         return self             # <<<<<<<<<<<<<<
+ * 
+ *     def deparam(self, params):
+ */
+  __Pyx_TraceLine(133,0,__PYX_ERR(1, 133, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(((PyObject *)__pyx_v_self));
+  __pyx_r = ((PyObject *)__pyx_v_self);
+  goto __pyx_L0;
+
+  /* "url/url.pyx":130
+ *         return self
+ * 
+ *     def defrag(self):             # <<<<<<<<<<<<<<
+ *         '''Remove the fragment from this url'''
+ *         self.ptr.defrag()
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_AddTraceback("url.url.StringURL.defrag", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":135
+ *         return self
+ * 
+ *     def deparam(self, params):             # <<<<<<<<<<<<<<
+ *         '''Strip any of the provided parameters out of the url'''
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_23deparam(PyObject *__pyx_v_self, PyObject *__pyx_v_params); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_22deparam[] = "Strip any of the provided parameters out of the url";
+static PyObject *__pyx_pw_3url_3url_9StringURL_23deparam(PyObject *__pyx_v_self, PyObject *__pyx_v_params) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("deparam (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_22deparam(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_params));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+static PyObject *__pyx_gb_3url_3url_9StringURL_7deparam_2generator(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value); /* proto */
+
+/* "url/url.pyx":137
  *     def deparam(self, params):
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)             # <<<<<<<<<<<<<<
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)             # <<<<<<<<<<<<<<
  *         self.ptr.deparam(lowered)
  *         return self
  */
 
-static PyObject *__pyx_pf_3url_3url_3URL_7deparam_genexpr(PyObject *__pyx_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_7deparam_genexpr(PyObject *__pyx_self) {
   struct __pyx_obj_3url_3url___pyx_scope_struct_1_genexpr *__pyx_cur_scope;
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
@@ -3904,9 +4221,9 @@ static PyObject *__pyx_pf_3url_3url_3URL_7deparam_genexpr(PyObject *__pyx_self) 
   __pyx_cur_scope->__pyx_outer_scope = (struct __pyx_obj_3url_3url___pyx_scope_struct__deparam *) __pyx_self;
   __Pyx_INCREF(((PyObject *)__pyx_cur_scope->__pyx_outer_scope));
   __Pyx_GIVEREF(__pyx_cur_scope->__pyx_outer_scope);
-  __Pyx_TraceCall("genexpr", __pyx_f[1], 125, 0, __PYX_ERR(1, 125, __pyx_L1_error));
+  __Pyx_TraceCall("genexpr", __pyx_f[1], 137, 0, __PYX_ERR(1, 137, __pyx_L1_error));
   {
-    __pyx_CoroutineObject *gen = __Pyx_Generator_New((__pyx_coroutine_body_t) __pyx_gb_3url_3url_3URL_7deparam_2generator, (PyObject *) __pyx_cur_scope, __pyx_n_s_genexpr, __pyx_n_s_deparam_locals_genexpr, __pyx_n_s_url_url); if (unlikely(!gen)) __PYX_ERR(1, 125, __pyx_L1_error)
+    __pyx_CoroutineObject *gen = __Pyx_Generator_New((__pyx_coroutine_body_t) __pyx_gb_3url_3url_9StringURL_7deparam_2generator, (PyObject *) __pyx_cur_scope, __pyx_n_s_genexpr, __pyx_n_s_deparam_locals_genexpr, __pyx_n_s_url_url); if (unlikely(!gen)) __PYX_ERR(1, 137, __pyx_L1_error)
     __Pyx_DECREF(__pyx_cur_scope);
     __Pyx_RefNannyFinishContext();
     return (PyObject *) gen;
@@ -3914,7 +4231,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_7deparam_genexpr(PyObject *__pyx_self) 
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.deparam.genexpr", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.deparam.genexpr", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __Pyx_DECREF(((PyObject *)__pyx_cur_scope));
   __Pyx_XGIVEREF(__pyx_r);
@@ -3923,7 +4240,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_7deparam_genexpr(PyObject *__pyx_self) 
   return __pyx_r;
 }
 
-static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value) /* generator body */
+static PyObject *__pyx_gb_3url_3url_9StringURL_7deparam_2generator(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value) /* generator body */
 {
   struct __pyx_obj_3url_3url___pyx_scope_struct_1_genexpr *__pyx_cur_scope = ((struct __pyx_obj_3url_3url___pyx_scope_struct_1_genexpr *)__pyx_generator->closure);
   PyObject *__pyx_r = NULL;
@@ -3943,32 +4260,32 @@ static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObje
     return NULL;
   }
   __pyx_L3_first_run:;
-  if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 125, __pyx_L1_error)
-  if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_params)) { __Pyx_RaiseClosureNameError("params"); __PYX_ERR(1, 125, __pyx_L1_error) }
+  if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 137, __pyx_L1_error)
+  if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_params)) { __Pyx_RaiseClosureNameError("params"); __PYX_ERR(1, 137, __pyx_L1_error) }
   if (likely(PyList_CheckExact(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_params)) || PyTuple_CheckExact(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_params)) {
     __pyx_t_1 = __pyx_cur_scope->__pyx_outer_scope->__pyx_v_params; __Pyx_INCREF(__pyx_t_1); __pyx_t_2 = 0;
     __pyx_t_3 = NULL;
   } else {
-    __pyx_t_2 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_params); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 125, __pyx_L1_error)
+    __pyx_t_2 = -1; __pyx_t_1 = PyObject_GetIter(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_params); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 125, __pyx_L1_error)
+    __pyx_t_3 = Py_TYPE(__pyx_t_1)->tp_iternext; if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 137, __pyx_L1_error)
   }
   for (;;) {
     if (likely(!__pyx_t_3)) {
       if (likely(PyList_CheckExact(__pyx_t_1))) {
         if (__pyx_t_2 >= PyList_GET_SIZE(__pyx_t_1)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(1, 125, __pyx_L1_error)
+        __pyx_t_4 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(1, 137, __pyx_L1_error)
         #else
-        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 125, __pyx_L1_error)
+        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         #endif
       } else {
         if (__pyx_t_2 >= PyTuple_GET_SIZE(__pyx_t_1)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(1, 125, __pyx_L1_error)
+        __pyx_t_4 = PyTuple_GET_ITEM(__pyx_t_1, __pyx_t_2); __Pyx_INCREF(__pyx_t_4); __pyx_t_2++; if (unlikely(0 < 0)) __PYX_ERR(1, 137, __pyx_L1_error)
         #else
-        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 125, __pyx_L1_error)
+        __pyx_t_4 = PySequence_ITEM(__pyx_t_1, __pyx_t_2); __pyx_t_2++; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 137, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         #endif
       }
@@ -3978,7 +4295,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObje
         PyObject* exc_type = PyErr_Occurred();
         if (exc_type) {
           if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-          else __PYX_ERR(1, 125, __pyx_L1_error)
+          else __PYX_ERR(1, 137, __pyx_L1_error)
         }
         break;
       }
@@ -3988,7 +4305,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObje
     __Pyx_XDECREF_SET(__pyx_cur_scope->__pyx_v_p, __pyx_t_4);
     __Pyx_GIVEREF(__pyx_t_4);
     __pyx_t_4 = 0;
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_cur_scope->__pyx_v_p, __pyx_n_s_lower); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 125, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_cur_scope->__pyx_v_p, __pyx_n_s_lower); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 137, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __pyx_t_6 = NULL;
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_5))) {
@@ -4001,15 +4318,18 @@ static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObje
       }
     }
     if (__pyx_t_6) {
-      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_6); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 125, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_6); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 137, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     } else {
-      __pyx_t_4 = __Pyx_PyObject_CallNoArg(__pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 125, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_CallNoArg(__pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 137, __pyx_L1_error)
     }
     __Pyx_GOTREF(__pyx_t_4);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    __pyx_r = __pyx_t_4;
-    __pyx_t_4 = 0;
+    __pyx_t_5 = __pyx_f_3url_3url_as_bytes(__pyx_t_4); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 137, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_5);
+    __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
+    __pyx_r = __pyx_t_5;
+    __pyx_t_5 = 0;
     __Pyx_XGIVEREF(__pyx_t_1);
     __pyx_cur_scope->__pyx_t_0 = __pyx_t_1;
     __pyx_cur_scope->__pyx_t_1 = __pyx_t_2;
@@ -4025,7 +4345,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObje
     __Pyx_XGOTREF(__pyx_t_1);
     __pyx_t_2 = __pyx_cur_scope->__pyx_t_1;
     __pyx_t_3 = __pyx_cur_scope->__pyx_t_2;
-    if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 125, __pyx_L1_error)
+    if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 137, __pyx_L1_error)
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
@@ -4046,15 +4366,15 @@ static PyObject *__pyx_gb_3url_3url_3URL_7deparam_2generator(__pyx_CoroutineObje
   return __pyx_r;
 }
 
-/* "url/url.pyx":123
+/* "url/url.pyx":135
  *         return self
  * 
  *     def deparam(self, params):             # <<<<<<<<<<<<<<
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
  */
 
-static PyObject *__pyx_pf_3url_3url_3URL_18deparam(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_params) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_22deparam(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_params) {
   struct __pyx_obj_3url_3url___pyx_scope_struct__deparam *__pyx_cur_scope;
   PyObject *__pyx_v_lowered = NULL;
   PyObject *__pyx_r = NULL;
@@ -4070,70 +4390,70 @@ static PyObject *__pyx_pf_3url_3url_3URL_18deparam(struct __pyx_obj_3url_3url_UR
     return NULL;
   }
   __Pyx_GOTREF(__pyx_cur_scope);
-  __Pyx_TraceCall("deparam", __pyx_f[1], 123, 0, __PYX_ERR(1, 123, __pyx_L1_error));
+  __Pyx_TraceCall("deparam", __pyx_f[1], 135, 0, __PYX_ERR(1, 135, __pyx_L1_error));
   __pyx_cur_scope->__pyx_v_params = __pyx_v_params;
   __Pyx_INCREF(__pyx_cur_scope->__pyx_v_params);
   __Pyx_GIVEREF(__pyx_cur_scope->__pyx_v_params);
 
-  /* "url/url.pyx":125
+  /* "url/url.pyx":137
  *     def deparam(self, params):
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)             # <<<<<<<<<<<<<<
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)             # <<<<<<<<<<<<<<
  *         self.ptr.deparam(lowered)
  *         return self
  */
-  __Pyx_TraceLine(125,0,__PYX_ERR(1, 125, __pyx_L1_error))
-  __pyx_t_1 = __pyx_pf_3url_3url_3URL_7deparam_genexpr(((PyObject*)__pyx_cur_scope)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 125, __pyx_L1_error)
+  __Pyx_TraceLine(137,0,__PYX_ERR(1, 137, __pyx_L1_error))
+  __pyx_t_1 = __pyx_pf_3url_3url_9StringURL_7deparam_genexpr(((PyObject*)__pyx_cur_scope)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __pyx_convert_unordered_set_from_py_std_3a__3a_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 125, __pyx_L1_error)
+  __pyx_t_2 = __pyx_convert_unordered_set_from_py_std_3a__3a_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 137, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   try {
     __pyx_t_3 = std::unordered_set<std::string> (__pyx_t_2);
   } catch(...) {
     __Pyx_CppExn2PyErr();
-    __PYX_ERR(1, 125, __pyx_L1_error)
+    __PYX_ERR(1, 137, __pyx_L1_error)
   }
-  __pyx_t_1 = __pyx_convert_unordered_set_to_py_std_3a__3a_string(__pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 125, __pyx_L1_error)
+  __pyx_t_1 = __pyx_convert_unordered_set_to_py_std_3a__3a_string(__pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 137, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_lowered = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "url/url.pyx":126
+  /* "url/url.pyx":138
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
  *         self.ptr.deparam(lowered)             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(126,0,__PYX_ERR(1, 126, __pyx_L1_error))
-  __pyx_t_3 = __pyx_convert_unordered_set_from_py_std_3a__3a_string(__pyx_v_lowered); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 126, __pyx_L1_error)
+  __Pyx_TraceLine(138,0,__PYX_ERR(1, 138, __pyx_L1_error))
+  __pyx_t_3 = __pyx_convert_unordered_set_from_py_std_3a__3a_string(__pyx_v_lowered); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 138, __pyx_L1_error)
   __pyx_v_self->ptr->deparam(__pyx_t_3);
 
-  /* "url/url.pyx":127
- *         lowered = unordered_set[string](p.lower() for p in params)
+  /* "url/url.pyx":139
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
  *         self.ptr.deparam(lowered)
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def filter_params(self, function):
  */
-  __Pyx_TraceLine(127,0,__PYX_ERR(1, 127, __pyx_L1_error))
+  __Pyx_TraceLine(139,0,__PYX_ERR(1, 139, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":123
+  /* "url/url.pyx":135
  *         return self
  * 
  *     def deparam(self, params):             # <<<<<<<<<<<<<<
  *         '''Strip any of the provided parameters out of the url'''
- *         lowered = unordered_set[string](p.lower() for p in params)
+ *         lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.deparam", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.deparam", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XDECREF(__pyx_v_lowered);
@@ -4144,51 +4464,51 @@ static PyObject *__pyx_pf_3url_3url_3URL_18deparam(struct __pyx_obj_3url_3url_UR
   return __pyx_r;
 }
 
-/* "url/url.pyx":129
+/* "url/url.pyx":141
  *         return self
  * 
  *     def filter_params(self, function):             # <<<<<<<<<<<<<<
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_21filter_params(PyObject *__pyx_v_self, PyObject *__pyx_v_function); /*proto*/
-static char __pyx_doc_3url_3url_3URL_20filter_params[] = "Remove parameters if function(name, value)";
-static PyObject *__pyx_pw_3url_3url_3URL_21filter_params(PyObject *__pyx_v_self, PyObject *__pyx_v_function) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_25filter_params(PyObject *__pyx_v_self, PyObject *__pyx_v_function); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_24filter_params[] = "Remove parameters if function(name, value), name and value are bytes.";
+static PyObject *__pyx_pw_3url_3url_9StringURL_25filter_params(PyObject *__pyx_v_self, PyObject *__pyx_v_function) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("filter_params (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_20filter_params(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_function));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_24filter_params(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_function));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-/* "url/url.pyx":131
+/* "url/url.pyx":143
  *     def filter_params(self, function):
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):             # <<<<<<<<<<<<<<
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_13filter_params_1keep(PyObject *__pyx_self, PyObject *__pyx_v_query); /*proto*/
-static PyMethodDef __pyx_mdef_3url_3url_3URL_13filter_params_1keep = {"keep", (PyCFunction)__pyx_pw_3url_3url_3URL_13filter_params_1keep, METH_O, 0};
-static PyObject *__pyx_pw_3url_3url_3URL_13filter_params_1keep(PyObject *__pyx_self, PyObject *__pyx_v_query) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_13filter_params_1keep(PyObject *__pyx_self, PyObject *__pyx_v_query); /*proto*/
+static PyMethodDef __pyx_mdef_3url_3url_9StringURL_13filter_params_1keep = {"keep", (PyCFunction)__pyx_pw_3url_3url_9StringURL_13filter_params_1keep, METH_O, 0};
+static PyObject *__pyx_pw_3url_3url_9StringURL_13filter_params_1keep(PyObject *__pyx_self, PyObject *__pyx_v_query) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("keep (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_13filter_params_keep(__pyx_self, ((PyObject *)__pyx_v_query));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_13filter_params_keep(__pyx_self, ((PyObject *)__pyx_v_query));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_self, PyObject *__pyx_v_query) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_13filter_params_keep(PyObject *__pyx_self, PyObject *__pyx_v_query) {
   struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params *__pyx_cur_scope;
   struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params *__pyx_outer_scope;
   PyObject *__pyx_v_name = NULL;
@@ -4208,19 +4528,19 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
   __Pyx_RefNannySetupContext("keep", 0);
   __pyx_outer_scope = (struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params *) __Pyx_CyFunction_GetClosure(__pyx_self);
   __pyx_cur_scope = __pyx_outer_scope;
-  __Pyx_TraceCall("keep", __pyx_f[1], 131, 0, __PYX_ERR(1, 131, __pyx_L1_error));
+  __Pyx_TraceCall("keep", __pyx_f[1], 143, 0, __PYX_ERR(1, 143, __pyx_L1_error));
 
-  /* "url/url.pyx":132
- *         '''Remove parameters if function(name, value)'''
+  /* "url/url.pyx":144
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):
  *             name, _, value = query.partition('=')             # <<<<<<<<<<<<<<
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  */
-  __Pyx_TraceLine(132,0,__PYX_ERR(1, 132, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_query, __pyx_n_s_partition); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 132, __pyx_L1_error)
+  __Pyx_TraceLine(144,0,__PYX_ERR(1, 144, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_query, __pyx_n_s_partition); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 144, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_tuple__8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 132, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_tuple__9, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 144, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if ((likely(PyTuple_CheckExact(__pyx_t_2))) || (PyList_CheckExact(__pyx_t_2))) {
@@ -4233,7 +4553,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
     if (unlikely(size != 3)) {
       if (size > 3) __Pyx_RaiseTooManyValuesError(3);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(1, 132, __pyx_L1_error)
+      __PYX_ERR(1, 144, __pyx_L1_error)
     }
     #if CYTHON_COMPILING_IN_CPYTHON
     if (likely(PyTuple_CheckExact(sequence))) {
@@ -4249,17 +4569,17 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
     __Pyx_INCREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_t_4);
     #else
-    __pyx_t_1 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 132, __pyx_L1_error)
+    __pyx_t_1 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 144, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 132, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 144, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 132, __pyx_L1_error)
+    __pyx_t_4 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 144, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     #endif
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   } else {
     Py_ssize_t index = -1;
-    __pyx_t_5 = PyObject_GetIter(__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 132, __pyx_L1_error)
+    __pyx_t_5 = PyObject_GetIter(__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 144, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_6 = Py_TYPE(__pyx_t_5)->tp_iternext;
@@ -4269,7 +4589,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
     __Pyx_GOTREF(__pyx_t_3);
     index = 2; __pyx_t_4 = __pyx_t_6(__pyx_t_5); if (unlikely(!__pyx_t_4)) goto __pyx_L3_unpacking_failed;
     __Pyx_GOTREF(__pyx_t_4);
-    if (__Pyx_IternextUnpackEndCheck(__pyx_t_6(__pyx_t_5), 3) < 0) __PYX_ERR(1, 132, __pyx_L1_error)
+    if (__Pyx_IternextUnpackEndCheck(__pyx_t_6(__pyx_t_5), 3) < 0) __PYX_ERR(1, 144, __pyx_L1_error)
     __pyx_t_6 = NULL;
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     goto __pyx_L4_unpacking_done;
@@ -4277,7 +4597,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __pyx_t_6 = NULL;
     if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-    __PYX_ERR(1, 132, __pyx_L1_error)
+    __PYX_ERR(1, 144, __pyx_L1_error)
     __pyx_L4_unpacking_done:;
   }
   __pyx_v_name = __pyx_t_1;
@@ -4287,16 +4607,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
   __pyx_v_value = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "url/url.pyx":133
+  /* "url/url.pyx":145
  *         def keep(query):
  *             name, _, value = query.partition('=')
  *             return not function(name, value)             # <<<<<<<<<<<<<<
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))
  */
-  __Pyx_TraceLine(133,0,__PYX_ERR(1, 133, __pyx_L1_error))
+  __Pyx_TraceLine(145,0,__PYX_ERR(1, 145, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  if (unlikely(!__pyx_cur_scope->__pyx_v_function)) { __Pyx_RaiseClosureNameError("function"); __PYX_ERR(1, 133, __pyx_L1_error) }
+  if (unlikely(!__pyx_cur_scope->__pyx_v_function)) { __Pyx_RaiseClosureNameError("function"); __PYX_ERR(1, 145, __pyx_L1_error) }
   __Pyx_INCREF(__pyx_cur_scope->__pyx_v_function);
   __pyx_t_4 = __pyx_cur_scope->__pyx_v_function; __pyx_t_3 = NULL;
   __pyx_t_7 = 0;
@@ -4310,7 +4630,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
       __pyx_t_7 = 1;
     }
   }
-  __pyx_t_1 = PyTuple_New(2+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 133, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(2+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 145, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   if (__pyx_t_3) {
     __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_3); __pyx_t_3 = NULL;
@@ -4321,21 +4641,21 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
   __Pyx_INCREF(__pyx_v_value);
   __Pyx_GIVEREF(__pyx_v_value);
   PyTuple_SET_ITEM(__pyx_t_1, 1+__pyx_t_7, __pyx_v_value);
-  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 133, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_t_1, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 145, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(1, 133, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(1, 145, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = __Pyx_PyBool_FromLong((!__pyx_t_8)); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 133, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyBool_FromLong((!__pyx_t_8)); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 145, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_r = __pyx_t_2;
   __pyx_t_2 = 0;
   goto __pyx_L0;
 
-  /* "url/url.pyx":131
+  /* "url/url.pyx":143
  *     def filter_params(self, function):
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):             # <<<<<<<<<<<<<<
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
@@ -4348,7 +4668,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
   __Pyx_XDECREF(__pyx_t_3);
   __Pyx_XDECREF(__pyx_t_4);
   __Pyx_XDECREF(__pyx_t_5);
-  __Pyx_AddTraceback("url.url.URL.filter_params.keep", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.filter_params.keep", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XDECREF(__pyx_v_name);
@@ -4359,9 +4679,9 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_keep(PyObject *__pyx_se
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
-static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value); /* proto */
+static PyObject *__pyx_gb_3url_3url_9StringURL_13filter_params_4generator1(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value); /* proto */
 
-/* "url/url.pyx":134
+/* "url/url.pyx":146
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))             # <<<<<<<<<<<<<<
@@ -4369,7 +4689,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
  *         return self
  */
 
-static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_2genexpr(PyObject *__pyx_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_13filter_params_2genexpr(PyObject *__pyx_self) {
   struct __pyx_obj_3url_3url___pyx_scope_struct_3_genexpr *__pyx_cur_scope;
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
@@ -4384,9 +4704,9 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_2genexpr(PyObject *__py
   __pyx_cur_scope->__pyx_outer_scope = (struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params *) __pyx_self;
   __Pyx_INCREF(((PyObject *)__pyx_cur_scope->__pyx_outer_scope));
   __Pyx_GIVEREF(__pyx_cur_scope->__pyx_outer_scope);
-  __Pyx_TraceCall("genexpr", __pyx_f[1], 134, 0, __PYX_ERR(1, 134, __pyx_L1_error));
+  __Pyx_TraceCall("genexpr", __pyx_f[1], 146, 0, __PYX_ERR(1, 146, __pyx_L1_error));
   {
-    __pyx_CoroutineObject *gen = __Pyx_Generator_New((__pyx_coroutine_body_t) __pyx_gb_3url_3url_3URL_13filter_params_4generator1, (PyObject *) __pyx_cur_scope, __pyx_n_s_genexpr, __pyx_n_s_filter_params_locals_genexpr, __pyx_n_s_url_url); if (unlikely(!gen)) __PYX_ERR(1, 134, __pyx_L1_error)
+    __pyx_CoroutineObject *gen = __Pyx_Generator_New((__pyx_coroutine_body_t) __pyx_gb_3url_3url_9StringURL_13filter_params_4generator1, (PyObject *) __pyx_cur_scope, __pyx_n_s_genexpr, __pyx_n_s_filter_params_locals_genexpr, __pyx_n_s_url_url); if (unlikely(!gen)) __PYX_ERR(1, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_cur_scope);
     __Pyx_RefNannyFinishContext();
     return (PyObject *) gen;
@@ -4394,7 +4714,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_2genexpr(PyObject *__py
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.filter_params.genexpr", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.filter_params.genexpr", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __Pyx_DECREF(((PyObject *)__pyx_cur_scope));
   __Pyx_XGIVEREF(__pyx_r);
@@ -4403,7 +4723,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_2genexpr(PyObject *__py
   return __pyx_r;
 }
 
-static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value) /* generator body */
+static PyObject *__pyx_gb_3url_3url_9StringURL_13filter_params_4generator1(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value) /* generator body */
 {
   struct __pyx_obj_3url_3url___pyx_scope_struct_3_genexpr *__pyx_cur_scope = ((struct __pyx_obj_3url_3url___pyx_scope_struct_3_genexpr *)__pyx_generator->closure);
   PyObject *__pyx_r = NULL;
@@ -4423,23 +4743,23 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
     return NULL;
   }
   __pyx_L3_first_run:;
-  if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 134, __pyx_L1_error)
-  if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self)) { __Pyx_RaiseClosureNameError("self"); __PYX_ERR(1, 134, __pyx_L1_error) }
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self), __pyx_n_s_query); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 134, __pyx_L1_error)
+  if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 146, __pyx_L1_error)
+  if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self)) { __Pyx_RaiseClosureNameError("self"); __PYX_ERR(1, 146, __pyx_L1_error) }
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self), __pyx_n_s_query); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_tuple__10, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 134, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_tuple__11, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   if (likely(PyList_CheckExact(__pyx_t_1)) || PyTuple_CheckExact(__pyx_t_1)) {
     __pyx_t_2 = __pyx_t_1; __Pyx_INCREF(__pyx_t_2); __pyx_t_3 = 0;
     __pyx_t_4 = NULL;
   } else {
-    __pyx_t_3 = -1; __pyx_t_2 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 134, __pyx_L1_error)
+    __pyx_t_3 = -1; __pyx_t_2 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_4 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 134, __pyx_L1_error)
+    __pyx_t_4 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 146, __pyx_L1_error)
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   for (;;) {
@@ -4447,17 +4767,17 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
       if (likely(PyList_CheckExact(__pyx_t_2))) {
         if (__pyx_t_3 >= PyList_GET_SIZE(__pyx_t_2)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 134, __pyx_L1_error)
+        __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 146, __pyx_L1_error)
         #else
-        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 134, __pyx_L1_error)
+        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 146, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         #endif
       } else {
         if (__pyx_t_3 >= PyTuple_GET_SIZE(__pyx_t_2)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_1 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 134, __pyx_L1_error)
+        __pyx_t_1 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 146, __pyx_L1_error)
         #else
-        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 134, __pyx_L1_error)
+        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 146, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         #endif
       }
@@ -4467,7 +4787,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
         PyObject* exc_type = PyErr_Occurred();
         if (exc_type) {
           if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-          else __PYX_ERR(1, 134, __pyx_L1_error)
+          else __PYX_ERR(1, 146, __pyx_L1_error)
         }
         break;
       }
@@ -4477,16 +4797,16 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
     __Pyx_XDECREF_SET(__pyx_cur_scope->__pyx_v_q, __pyx_t_1);
     __Pyx_GIVEREF(__pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_cur_scope->__pyx_v_q); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 134, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_cur_scope->__pyx_v_q); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 146, __pyx_L1_error)
     if (__pyx_t_6) {
     } else {
       __pyx_t_5 = __pyx_t_6;
       goto __pyx_L7_bool_binop_done;
     }
-    if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep)) { __Pyx_RaiseClosureNameError("keep"); __PYX_ERR(1, 134, __pyx_L1_error) }
-    __pyx_t_1 = __pyx_pf_3url_3url_3URL_13filter_params_keep(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep, __pyx_cur_scope->__pyx_v_q); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 134, __pyx_L1_error)
+    if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep)) { __Pyx_RaiseClosureNameError("keep"); __PYX_ERR(1, 146, __pyx_L1_error) }
+    __pyx_t_1 = __pyx_pf_3url_3url_9StringURL_13filter_params_keep(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep, __pyx_cur_scope->__pyx_v_q); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 146, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 134, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 146, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = __pyx_t_6;
     __pyx_L7_bool_binop_done:;
@@ -4508,7 +4828,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
       __Pyx_XGOTREF(__pyx_t_2);
       __pyx_t_3 = __pyx_cur_scope->__pyx_t_1;
       __pyx_t_4 = __pyx_cur_scope->__pyx_t_2;
-      if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 134, __pyx_L1_error)
+      if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 146, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -4527,9 +4847,9 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_4generator1(__pyx_Corou
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
-static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value); /* proto */
+static PyObject *__pyx_gb_3url_3url_9StringURL_13filter_params_7generator2(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value); /* proto */
 
-/* "url/url.pyx":135
+/* "url/url.pyx":147
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))             # <<<<<<<<<<<<<<
@@ -4537,7 +4857,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
  * 
  */
 
-static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_5genexpr(PyObject *__pyx_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_13filter_params_5genexpr(PyObject *__pyx_self) {
   struct __pyx_obj_3url_3url___pyx_scope_struct_4_genexpr *__pyx_cur_scope;
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
@@ -4552,9 +4872,9 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_5genexpr(PyObject *__py
   __pyx_cur_scope->__pyx_outer_scope = (struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params *) __pyx_self;
   __Pyx_INCREF(((PyObject *)__pyx_cur_scope->__pyx_outer_scope));
   __Pyx_GIVEREF(__pyx_cur_scope->__pyx_outer_scope);
-  __Pyx_TraceCall("genexpr", __pyx_f[1], 135, 0, __PYX_ERR(1, 135, __pyx_L1_error));
+  __Pyx_TraceCall("genexpr", __pyx_f[1], 147, 0, __PYX_ERR(1, 147, __pyx_L1_error));
   {
-    __pyx_CoroutineObject *gen = __Pyx_Generator_New((__pyx_coroutine_body_t) __pyx_gb_3url_3url_3URL_13filter_params_7generator2, (PyObject *) __pyx_cur_scope, __pyx_n_s_genexpr, __pyx_n_s_filter_params_locals_genexpr, __pyx_n_s_url_url); if (unlikely(!gen)) __PYX_ERR(1, 135, __pyx_L1_error)
+    __pyx_CoroutineObject *gen = __Pyx_Generator_New((__pyx_coroutine_body_t) __pyx_gb_3url_3url_9StringURL_13filter_params_7generator2, (PyObject *) __pyx_cur_scope, __pyx_n_s_genexpr, __pyx_n_s_filter_params_locals_genexpr, __pyx_n_s_url_url); if (unlikely(!gen)) __PYX_ERR(1, 147, __pyx_L1_error)
     __Pyx_DECREF(__pyx_cur_scope);
     __Pyx_RefNannyFinishContext();
     return (PyObject *) gen;
@@ -4562,7 +4882,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_5genexpr(PyObject *__py
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.filter_params.genexpr", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.filter_params.genexpr", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __Pyx_DECREF(((PyObject *)__pyx_cur_scope));
   __Pyx_XGIVEREF(__pyx_r);
@@ -4571,7 +4891,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_13filter_params_5genexpr(PyObject *__py
   return __pyx_r;
 }
 
-static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value) /* generator body */
+static PyObject *__pyx_gb_3url_3url_9StringURL_13filter_params_7generator2(__pyx_CoroutineObject *__pyx_generator, PyObject *__pyx_sent_value) /* generator body */
 {
   struct __pyx_obj_3url_3url___pyx_scope_struct_4_genexpr *__pyx_cur_scope = ((struct __pyx_obj_3url_3url___pyx_scope_struct_4_genexpr *)__pyx_generator->closure);
   PyObject *__pyx_r = NULL;
@@ -4591,23 +4911,23 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
     return NULL;
   }
   __pyx_L3_first_run:;
-  if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 135, __pyx_L1_error)
-  if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self)) { __Pyx_RaiseClosureNameError("self"); __PYX_ERR(1, 135, __pyx_L1_error) }
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self), __pyx_n_s_params); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 135, __pyx_L1_error)
+  if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 147, __pyx_L1_error)
+  if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self)) { __Pyx_RaiseClosureNameError("self"); __PYX_ERR(1, 147, __pyx_L1_error) }
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_outer_scope->__pyx_v_self), __pyx_n_s_params); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 147, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 135, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_split); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 147, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_tuple__12, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 135, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_tuple__13, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 147, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   if (likely(PyList_CheckExact(__pyx_t_1)) || PyTuple_CheckExact(__pyx_t_1)) {
     __pyx_t_2 = __pyx_t_1; __Pyx_INCREF(__pyx_t_2); __pyx_t_3 = 0;
     __pyx_t_4 = NULL;
   } else {
-    __pyx_t_3 = -1; __pyx_t_2 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 135, __pyx_L1_error)
+    __pyx_t_3 = -1; __pyx_t_2 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 147, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_4 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 135, __pyx_L1_error)
+    __pyx_t_4 = Py_TYPE(__pyx_t_2)->tp_iternext; if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 147, __pyx_L1_error)
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   for (;;) {
@@ -4615,17 +4935,17 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
       if (likely(PyList_CheckExact(__pyx_t_2))) {
         if (__pyx_t_3 >= PyList_GET_SIZE(__pyx_t_2)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 135, __pyx_L1_error)
+        __pyx_t_1 = PyList_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 147, __pyx_L1_error)
         #else
-        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 135, __pyx_L1_error)
+        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 147, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         #endif
       } else {
         if (__pyx_t_3 >= PyTuple_GET_SIZE(__pyx_t_2)) break;
         #if CYTHON_COMPILING_IN_CPYTHON
-        __pyx_t_1 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 135, __pyx_L1_error)
+        __pyx_t_1 = PyTuple_GET_ITEM(__pyx_t_2, __pyx_t_3); __Pyx_INCREF(__pyx_t_1); __pyx_t_3++; if (unlikely(0 < 0)) __PYX_ERR(1, 147, __pyx_L1_error)
         #else
-        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 135, __pyx_L1_error)
+        __pyx_t_1 = PySequence_ITEM(__pyx_t_2, __pyx_t_3); __pyx_t_3++; if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 147, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         #endif
       }
@@ -4635,7 +4955,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
         PyObject* exc_type = PyErr_Occurred();
         if (exc_type) {
           if (likely(exc_type == PyExc_StopIteration || PyErr_GivenExceptionMatches(exc_type, PyExc_StopIteration))) PyErr_Clear();
-          else __PYX_ERR(1, 135, __pyx_L1_error)
+          else __PYX_ERR(1, 147, __pyx_L1_error)
         }
         break;
       }
@@ -4645,16 +4965,16 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
     __Pyx_XDECREF_SET(__pyx_cur_scope->__pyx_v_q, __pyx_t_1);
     __Pyx_GIVEREF(__pyx_t_1);
     __pyx_t_1 = 0;
-    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_cur_scope->__pyx_v_q); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 135, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_cur_scope->__pyx_v_q); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 147, __pyx_L1_error)
     if (__pyx_t_6) {
     } else {
       __pyx_t_5 = __pyx_t_6;
       goto __pyx_L7_bool_binop_done;
     }
-    if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep)) { __Pyx_RaiseClosureNameError("keep"); __PYX_ERR(1, 135, __pyx_L1_error) }
-    __pyx_t_1 = __pyx_pf_3url_3url_3URL_13filter_params_keep(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep, __pyx_cur_scope->__pyx_v_q); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 135, __pyx_L1_error)
+    if (unlikely(!__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep)) { __Pyx_RaiseClosureNameError("keep"); __PYX_ERR(1, 147, __pyx_L1_error) }
+    __pyx_t_1 = __pyx_pf_3url_3url_9StringURL_13filter_params_keep(__pyx_cur_scope->__pyx_outer_scope->__pyx_v_keep, __pyx_cur_scope->__pyx_v_q); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 147, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 135, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(1, 147, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_t_5 = __pyx_t_6;
     __pyx_L7_bool_binop_done:;
@@ -4676,7 +4996,7 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
       __Pyx_XGOTREF(__pyx_t_2);
       __pyx_t_3 = __pyx_cur_scope->__pyx_t_1;
       __pyx_t_4 = __pyx_cur_scope->__pyx_t_2;
-      if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 135, __pyx_L1_error)
+      if (unlikely(!__pyx_sent_value)) __PYX_ERR(1, 147, __pyx_L1_error)
     }
   }
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
@@ -4696,15 +5016,15 @@ static PyObject *__pyx_gb_3url_3url_3URL_13filter_params_7generator2(__pyx_Corou
   return __pyx_r;
 }
 
-/* "url/url.pyx":129
+/* "url/url.pyx":141
  *         return self
  * 
  *     def filter_params(self, function):             # <<<<<<<<<<<<<<
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):
  */
 
-static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_function) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_24filter_params(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_function) {
   struct __pyx_obj_3url_3url___pyx_scope_struct_2_filter_params *__pyx_cur_scope;
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
@@ -4718,7 +5038,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3
     return NULL;
   }
   __Pyx_GOTREF(__pyx_cur_scope);
-  __Pyx_TraceCall("filter_params", __pyx_f[1], 129, 0, __PYX_ERR(1, 129, __pyx_L1_error));
+  __Pyx_TraceCall("filter_params", __pyx_f[1], 141, 0, __PYX_ERR(1, 141, __pyx_L1_error));
   __pyx_cur_scope->__pyx_v_self = __pyx_v_self;
   __Pyx_INCREF((PyObject *)__pyx_cur_scope->__pyx_v_self);
   __Pyx_GIVEREF((PyObject *)__pyx_cur_scope->__pyx_v_self);
@@ -4726,70 +5046,70 @@ static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3
   __Pyx_INCREF(__pyx_cur_scope->__pyx_v_function);
   __Pyx_GIVEREF(__pyx_cur_scope->__pyx_v_function);
 
-  /* "url/url.pyx":131
+  /* "url/url.pyx":143
  *     def filter_params(self, function):
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):             # <<<<<<<<<<<<<<
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  */
-  __Pyx_TraceLine(131,0,__PYX_ERR(1, 131, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_CyFunction_NewEx(&__pyx_mdef_3url_3url_3URL_13filter_params_1keep, 0, __pyx_n_s_filter_params_locals_keep, ((PyObject*)__pyx_cur_scope), __pyx_n_s_url_url, __pyx_d, ((PyObject *)__pyx_codeobj__15)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 131, __pyx_L1_error)
+  __Pyx_TraceLine(143,0,__PYX_ERR(1, 143, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_CyFunction_NewEx(&__pyx_mdef_3url_3url_9StringURL_13filter_params_1keep, 0, __pyx_n_s_filter_params_locals_keep, ((PyObject*)__pyx_cur_scope), __pyx_n_s_url_url, __pyx_d, ((PyObject *)__pyx_codeobj__16)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 143, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_GIVEREF(__pyx_t_1);
   __pyx_cur_scope->__pyx_v_keep = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "url/url.pyx":134
+  /* "url/url.pyx":146
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))             # <<<<<<<<<<<<<<
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))
  *         return self
  */
-  __Pyx_TraceLine(134,0,__PYX_ERR(1, 134, __pyx_L1_error))
-  __pyx_t_1 = __pyx_pf_3url_3url_3URL_13filter_params_2genexpr(((PyObject*)__pyx_cur_scope)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 134, __pyx_L1_error)
+  __Pyx_TraceLine(146,0,__PYX_ERR(1, 146, __pyx_L1_error))
+  __pyx_t_1 = __pyx_pf_3url_3url_9StringURL_13filter_params_2genexpr(((PyObject*)__pyx_cur_scope)); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyString_Join(__pyx_kp_s__9, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 134, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyString_Join(__pyx_kp_s__10, __pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 146, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (__Pyx_PyObject_SetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_v_self), __pyx_n_s_query, __pyx_t_2) < 0) __PYX_ERR(1, 134, __pyx_L1_error)
+  if (__Pyx_PyObject_SetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_v_self), __pyx_n_s_query, __pyx_t_2) < 0) __PYX_ERR(1, 146, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "url/url.pyx":135
+  /* "url/url.pyx":147
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(135,0,__PYX_ERR(1, 135, __pyx_L1_error))
-  __pyx_t_2 = __pyx_pf_3url_3url_3URL_13filter_params_5genexpr(((PyObject*)__pyx_cur_scope)); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 135, __pyx_L1_error)
+  __Pyx_TraceLine(147,0,__PYX_ERR(1, 147, __pyx_L1_error))
+  __pyx_t_2 = __pyx_pf_3url_3url_9StringURL_13filter_params_5genexpr(((PyObject*)__pyx_cur_scope)); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 147, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__11, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 135, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyString_Join(__pyx_kp_s__12, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 147, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (__Pyx_PyObject_SetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_v_self), __pyx_n_s_params, __pyx_t_1) < 0) __PYX_ERR(1, 135, __pyx_L1_error)
+  if (__Pyx_PyObject_SetAttrStr(((PyObject *)__pyx_cur_scope->__pyx_v_self), __pyx_n_s_params, __pyx_t_1) < 0) __PYX_ERR(1, 147, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "url/url.pyx":136
+  /* "url/url.pyx":148
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def deuserinfo(self):
  */
-  __Pyx_TraceLine(136,0,__PYX_ERR(1, 136, __pyx_L1_error))
+  __Pyx_TraceLine(148,0,__PYX_ERR(1, 148, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_cur_scope->__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_cur_scope->__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":129
+  /* "url/url.pyx":141
  *         return self
  * 
  *     def filter_params(self, function):             # <<<<<<<<<<<<<<
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):
  */
 
@@ -4797,7 +5117,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
   __Pyx_XDECREF(__pyx_t_2);
-  __Pyx_AddTraceback("url.url.URL.filter_params", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.filter_params", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_DECREF(((PyObject *)__pyx_cur_scope));
@@ -4807,7 +5127,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3
   return __pyx_r;
 }
 
-/* "url/url.pyx":138
+/* "url/url.pyx":150
  *         return self
  * 
  *     def deuserinfo(self):             # <<<<<<<<<<<<<<
@@ -4816,50 +5136,50 @@ static PyObject *__pyx_pf_3url_3url_3URL_20filter_params(struct __pyx_obj_3url_3
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_23deuserinfo(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_22deuserinfo[] = "Remove any userinfo";
-static PyObject *__pyx_pw_3url_3url_3URL_23deuserinfo(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_27deuserinfo(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_26deuserinfo[] = "Remove any userinfo";
+static PyObject *__pyx_pw_3url_3url_9StringURL_27deuserinfo(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("deuserinfo (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_22deuserinfo(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_26deuserinfo(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_22deuserinfo(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_26deuserinfo(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("deuserinfo", 0);
-  __Pyx_TraceCall("deuserinfo", __pyx_f[1], 138, 0, __PYX_ERR(1, 138, __pyx_L1_error));
+  __Pyx_TraceCall("deuserinfo", __pyx_f[1], 150, 0, __PYX_ERR(1, 150, __pyx_L1_error));
 
-  /* "url/url.pyx":140
+  /* "url/url.pyx":152
  *     def deuserinfo(self):
  *         '''Remove any userinfo'''
  *         self.ptr.deuserinfo()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(140,0,__PYX_ERR(1, 140, __pyx_L1_error))
+  __Pyx_TraceLine(152,0,__PYX_ERR(1, 152, __pyx_L1_error))
   __pyx_v_self->ptr->deuserinfo();
 
-  /* "url/url.pyx":141
+  /* "url/url.pyx":153
  *         '''Remove any userinfo'''
  *         self.ptr.deuserinfo()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def abspath(self):
  */
-  __Pyx_TraceLine(141,0,__PYX_ERR(1, 141, __pyx_L1_error))
+  __Pyx_TraceLine(153,0,__PYX_ERR(1, 153, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":138
+  /* "url/url.pyx":150
  *         return self
  * 
  *     def deuserinfo(self):             # <<<<<<<<<<<<<<
@@ -4869,7 +5189,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_22deuserinfo(struct __pyx_obj_3url_3url
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.deuserinfo", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.deuserinfo", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -4878,7 +5198,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_22deuserinfo(struct __pyx_obj_3url_3url
   return __pyx_r;
 }
 
-/* "url/url.pyx":143
+/* "url/url.pyx":155
  *         return self
  * 
  *     def abspath(self):             # <<<<<<<<<<<<<<
@@ -4887,50 +5207,50 @@ static PyObject *__pyx_pf_3url_3url_3URL_22deuserinfo(struct __pyx_obj_3url_3url
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_25abspath(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_24abspath[] = "Clear out any '..' and excessive slashes from the path";
-static PyObject *__pyx_pw_3url_3url_3URL_25abspath(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_29abspath(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_28abspath[] = "Clear out any '..' and excessive slashes from the path";
+static PyObject *__pyx_pw_3url_3url_9StringURL_29abspath(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("abspath (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_24abspath(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_28abspath(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_24abspath(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_28abspath(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("abspath", 0);
-  __Pyx_TraceCall("abspath", __pyx_f[1], 143, 0, __PYX_ERR(1, 143, __pyx_L1_error));
+  __Pyx_TraceCall("abspath", __pyx_f[1], 155, 0, __PYX_ERR(1, 155, __pyx_L1_error));
 
-  /* "url/url.pyx":145
+  /* "url/url.pyx":157
  *     def abspath(self):
  *         '''Clear out any '..' and excessive slashes from the path'''
  *         self.ptr.abspath()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(145,0,__PYX_ERR(1, 145, __pyx_L1_error))
+  __Pyx_TraceLine(157,0,__PYX_ERR(1, 157, __pyx_L1_error))
   __pyx_v_self->ptr->abspath();
 
-  /* "url/url.pyx":146
+  /* "url/url.pyx":158
  *         '''Clear out any '..' and excessive slashes from the path'''
  *         self.ptr.abspath()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def relative(self, other):
  */
-  __Pyx_TraceLine(146,0,__PYX_ERR(1, 146, __pyx_L1_error))
+  __Pyx_TraceLine(158,0,__PYX_ERR(1, 158, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":143
+  /* "url/url.pyx":155
  *         return self
  * 
  *     def abspath(self):             # <<<<<<<<<<<<<<
@@ -4940,7 +5260,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_24abspath(struct __pyx_obj_3url_3url_UR
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.abspath", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.abspath", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -4949,7 +5269,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_24abspath(struct __pyx_obj_3url_3url_UR
   return __pyx_r;
 }
 
-/* "url/url.pyx":148
+/* "url/url.pyx":160
  *         return self
  * 
  *     def relative(self, other):             # <<<<<<<<<<<<<<
@@ -4958,20 +5278,20 @@ static PyObject *__pyx_pf_3url_3url_3URL_24abspath(struct __pyx_obj_3url_3url_UR
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_27relative(PyObject *__pyx_v_self, PyObject *__pyx_v_other); /*proto*/
-static char __pyx_doc_3url_3url_3URL_26relative[] = "Evaluate other relative to self.";
-static PyObject *__pyx_pw_3url_3url_3URL_27relative(PyObject *__pyx_v_self, PyObject *__pyx_v_other) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_31relative(PyObject *__pyx_v_self, PyObject *__pyx_v_other); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_30relative[] = "Evaluate other relative to self.";
+static PyObject *__pyx_pw_3url_3url_9StringURL_31relative(PyObject *__pyx_v_self, PyObject *__pyx_v_other) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("relative (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_26relative(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_other));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_30relative(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_other));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_other) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_30relative(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_other) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -4983,30 +5303,30 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
   PyObject *__pyx_t_6 = NULL;
   PyObject *__pyx_t_7 = NULL;
   __Pyx_RefNannySetupContext("relative", 0);
-  __Pyx_TraceCall("relative", __pyx_f[1], 148, 0, __PYX_ERR(1, 148, __pyx_L1_error));
+  __Pyx_TraceCall("relative", __pyx_f[1], 160, 0, __PYX_ERR(1, 160, __pyx_L1_error));
 
-  /* "url/url.pyx":150
+  /* "url/url.pyx":162
  *     def relative(self, other):
  *         '''Evaluate other relative to self.'''
  *         if isinstance(other, basestring):             # <<<<<<<<<<<<<<
  *             return self.parse(other).relative_to(self)
  *         else:
  */
-  __Pyx_TraceLine(150,0,__PYX_ERR(1, 150, __pyx_L1_error))
+  __Pyx_TraceLine(162,0,__PYX_ERR(1, 162, __pyx_L1_error))
   __pyx_t_1 = __Pyx_PyBaseString_Check(__pyx_v_other); 
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "url/url.pyx":151
+    /* "url/url.pyx":163
  *         '''Evaluate other relative to self.'''
  *         if isinstance(other, basestring):
  *             return self.parse(other).relative_to(self)             # <<<<<<<<<<<<<<
  *         else:
  *             return other.relative_to(self)
  */
-    __Pyx_TraceLine(151,0,__PYX_ERR(1, 151, __pyx_L1_error))
+    __Pyx_TraceLine(163,0,__PYX_ERR(1, 163, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_parse); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 151, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_parse); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 163, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __pyx_t_6 = NULL;
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_5))) {
@@ -5019,21 +5339,21 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
       }
     }
     if (!__pyx_t_6) {
-      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 151, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_other); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 163, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
     } else {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 151, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 163, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_6); __pyx_t_6 = NULL;
       __Pyx_INCREF(__pyx_v_other);
       __Pyx_GIVEREF(__pyx_v_other);
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, __pyx_v_other);
-      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 151, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 163, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_relative_to); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 151, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_relative_to); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 163, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_4 = NULL;
@@ -5047,16 +5367,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
       }
     }
     if (!__pyx_t_4) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_5, ((PyObject *)__pyx_v_self)); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 151, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_5, ((PyObject *)__pyx_v_self)); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 163, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 151, __pyx_L1_error)
+      __pyx_t_7 = PyTuple_New(1+1); if (unlikely(!__pyx_t_7)) __PYX_ERR(1, 163, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_7);
       __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_7, 0, __pyx_t_4); __pyx_t_4 = NULL;
       __Pyx_INCREF(((PyObject *)__pyx_v_self));
       __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
       PyTuple_SET_ITEM(__pyx_t_7, 0+1, ((PyObject *)__pyx_v_self));
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 151, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_7, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 163, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     }
@@ -5065,7 +5385,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":150
+    /* "url/url.pyx":162
  *     def relative(self, other):
  *         '''Evaluate other relative to self.'''
  *         if isinstance(other, basestring):             # <<<<<<<<<<<<<<
@@ -5074,17 +5394,17 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
  */
   }
 
-  /* "url/url.pyx":153
+  /* "url/url.pyx":165
  *             return self.parse(other).relative_to(self)
  *         else:
  *             return other.relative_to(self)             # <<<<<<<<<<<<<<
  * 
  *     def relative_to(self, base):
  */
-  __Pyx_TraceLine(153,0,__PYX_ERR(1, 153, __pyx_L1_error))
+  __Pyx_TraceLine(165,0,__PYX_ERR(1, 165, __pyx_L1_error))
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_relative_to); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 153, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_other, __pyx_n_s_relative_to); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 165, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __pyx_t_7 = NULL;
     if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_5))) {
@@ -5097,16 +5417,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
       }
     }
     if (!__pyx_t_7) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_5, ((PyObject *)__pyx_v_self)); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 153, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_5, ((PyObject *)__pyx_v_self)); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 165, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 153, __pyx_L1_error)
+      __pyx_t_4 = PyTuple_New(1+1); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 165, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_7); __pyx_t_7 = NULL;
       __Pyx_INCREF(((PyObject *)__pyx_v_self));
       __Pyx_GIVEREF(((PyObject *)__pyx_v_self));
       PyTuple_SET_ITEM(__pyx_t_4, 0+1, ((PyObject *)__pyx_v_self));
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 153, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_4, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 165, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     }
@@ -5116,7 +5436,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
     goto __pyx_L0;
   }
 
-  /* "url/url.pyx":148
+  /* "url/url.pyx":160
  *         return self
  * 
  *     def relative(self, other):             # <<<<<<<<<<<<<<
@@ -5131,7 +5451,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
   __Pyx_XDECREF(__pyx_t_5);
   __Pyx_XDECREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_7);
-  __Pyx_AddTraceback("url.url.URL.relative", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.relative", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5140,7 +5460,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
   return __pyx_r;
 }
 
-/* "url/url.pyx":155
+/* "url/url.pyx":167
  *             return other.relative_to(self)
  * 
  *     def relative_to(self, base):             # <<<<<<<<<<<<<<
@@ -5149,20 +5469,20 @@ static PyObject *__pyx_pf_3url_3url_3URL_26relative(struct __pyx_obj_3url_3url_U
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_29relative_to(PyObject *__pyx_v_self, PyObject *__pyx_v_base); /*proto*/
-static char __pyx_doc_3url_3url_3URL_28relative_to[] = "Evaluate the new path relative to the current url";
-static PyObject *__pyx_pw_3url_3url_3URL_29relative_to(PyObject *__pyx_v_self, PyObject *__pyx_v_base) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_33relative_to(PyObject *__pyx_v_self, PyObject *__pyx_v_base); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_32relative_to[] = "Evaluate the new path relative to the current url";
+static PyObject *__pyx_pw_3url_3url_9StringURL_33relative_to(PyObject *__pyx_v_self, PyObject *__pyx_v_base) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("relative_to (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_28relative_to(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_base));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_32relative_to(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_base));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_base) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_32relative_to(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_base) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -5172,32 +5492,32 @@ static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3ur
   PyObject *__pyx_t_4 = NULL;
   PyObject *__pyx_t_5 = NULL;
   __Pyx_RefNannySetupContext("relative_to", 0);
-  __Pyx_TraceCall("relative_to", __pyx_f[1], 155, 0, __PYX_ERR(1, 155, __pyx_L1_error));
+  __Pyx_TraceCall("relative_to", __pyx_f[1], 167, 0, __PYX_ERR(1, 167, __pyx_L1_error));
 
-  /* "url/url.pyx":157
+  /* "url/url.pyx":169
  *     def relative_to(self, base):
  *         '''Evaluate the new path relative to the current url'''
  *         if isinstance(base, bytes):             # <<<<<<<<<<<<<<
  *             self.ptr.relative_to(<string>base)
  *         elif isinstance(base, unicode):
  */
-  __Pyx_TraceLine(157,0,__PYX_ERR(1, 157, __pyx_L1_error))
+  __Pyx_TraceLine(169,0,__PYX_ERR(1, 169, __pyx_L1_error))
   __pyx_t_1 = PyBytes_Check(__pyx_v_base); 
   __pyx_t_2 = (__pyx_t_1 != 0);
   if (__pyx_t_2) {
 
-    /* "url/url.pyx":158
+    /* "url/url.pyx":170
  *         '''Evaluate the new path relative to the current url'''
  *         if isinstance(base, bytes):
  *             self.ptr.relative_to(<string>base)             # <<<<<<<<<<<<<<
  *         elif isinstance(base, unicode):
  *             self.ptr.relative_to(<string>(base.encode('utf-8')))
  */
-    __Pyx_TraceLine(158,0,__PYX_ERR(1, 158, __pyx_L1_error))
-    __pyx_t_3 = __pyx_convert_string_from_py_std__in_string(__pyx_v_base); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 158, __pyx_L1_error)
+    __Pyx_TraceLine(170,0,__PYX_ERR(1, 170, __pyx_L1_error))
+    __pyx_t_3 = __pyx_convert_string_from_py_std__in_string(__pyx_v_base); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 170, __pyx_L1_error)
     __pyx_v_self->ptr->relative_to(((std::string)__pyx_t_3));
 
-    /* "url/url.pyx":157
+    /* "url/url.pyx":169
  *     def relative_to(self, base):
  *         '''Evaluate the new path relative to the current url'''
  *         if isinstance(base, bytes):             # <<<<<<<<<<<<<<
@@ -5207,36 +5527,36 @@ static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3ur
     goto __pyx_L3;
   }
 
-  /* "url/url.pyx":159
+  /* "url/url.pyx":171
  *         if isinstance(base, bytes):
  *             self.ptr.relative_to(<string>base)
  *         elif isinstance(base, unicode):             # <<<<<<<<<<<<<<
  *             self.ptr.relative_to(<string>(base.encode('utf-8')))
  *         else:
  */
-  __Pyx_TraceLine(159,0,__PYX_ERR(1, 159, __pyx_L1_error))
+  __Pyx_TraceLine(171,0,__PYX_ERR(1, 171, __pyx_L1_error))
   __pyx_t_2 = PyUnicode_Check(__pyx_v_base); 
   __pyx_t_1 = (__pyx_t_2 != 0);
   if (__pyx_t_1) {
 
-    /* "url/url.pyx":160
+    /* "url/url.pyx":172
  *             self.ptr.relative_to(<string>base)
  *         elif isinstance(base, unicode):
  *             self.ptr.relative_to(<string>(base.encode('utf-8')))             # <<<<<<<<<<<<<<
  *         else:
- *             self.ptr.relative_to(<const Url&>dereference((<URL?>base).ptr))
+ *             self.ptr.relative_to(<const Url&>dereference((<StringURL?>base).ptr))
  */
-    __Pyx_TraceLine(160,0,__PYX_ERR(1, 160, __pyx_L1_error))
-    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_base, __pyx_n_s_encode); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 160, __pyx_L1_error)
+    __Pyx_TraceLine(172,0,__PYX_ERR(1, 172, __pyx_L1_error))
+    __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_base, __pyx_n_s_encode); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 172, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_tuple__16, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 160, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_4, __pyx_tuple__17, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 172, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-    __pyx_t_3 = __pyx_convert_string_from_py_std__in_string(__pyx_t_5); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 160, __pyx_L1_error)
+    __pyx_t_3 = __pyx_convert_string_from_py_std__in_string(__pyx_t_5); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 172, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __pyx_v_self->ptr->relative_to(((std::string)__pyx_t_3));
 
-    /* "url/url.pyx":159
+    /* "url/url.pyx":171
  *         if isinstance(base, bytes):
  *             self.ptr.relative_to(<string>base)
  *         elif isinstance(base, unicode):             # <<<<<<<<<<<<<<
@@ -5246,44 +5566,44 @@ static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3ur
     goto __pyx_L3;
   }
 
-  /* "url/url.pyx":162
+  /* "url/url.pyx":174
  *             self.ptr.relative_to(<string>(base.encode('utf-8')))
  *         else:
- *             self.ptr.relative_to(<const Url&>dereference((<URL?>base).ptr))             # <<<<<<<<<<<<<<
+ *             self.ptr.relative_to(<const Url&>dereference((<StringURL?>base).ptr))             # <<<<<<<<<<<<<<
  *         self.ptr.abspath()
  *         return self
  */
-  __Pyx_TraceLine(162,0,__PYX_ERR(1, 162, __pyx_L1_error))
+  __Pyx_TraceLine(174,0,__PYX_ERR(1, 174, __pyx_L1_error))
   /*else*/ {
-    if (!(likely(__Pyx_TypeTest(__pyx_v_base, __pyx_ptype_3url_3url_URL)))) __PYX_ERR(1, 162, __pyx_L1_error)
-    __pyx_v_self->ptr->relative_to(((Url::Url const &)(*((struct __pyx_obj_3url_3url_URL *)__pyx_v_base)->ptr)));
+    if (!(likely(__Pyx_TypeTest(__pyx_v_base, __pyx_ptype_3url_3url_StringURL)))) __PYX_ERR(1, 174, __pyx_L1_error)
+    __pyx_v_self->ptr->relative_to(((Url::Url const &)(*((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_base)->ptr)));
   }
   __pyx_L3:;
 
-  /* "url/url.pyx":163
+  /* "url/url.pyx":175
  *         else:
- *             self.ptr.relative_to(<const Url&>dereference((<URL?>base).ptr))
+ *             self.ptr.relative_to(<const Url&>dereference((<StringURL?>base).ptr))
  *         self.ptr.abspath()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(163,0,__PYX_ERR(1, 163, __pyx_L1_error))
+  __Pyx_TraceLine(175,0,__PYX_ERR(1, 175, __pyx_L1_error))
   __pyx_v_self->ptr->abspath();
 
-  /* "url/url.pyx":164
- *             self.ptr.relative_to(<const Url&>dereference((<URL?>base).ptr))
+  /* "url/url.pyx":176
+ *             self.ptr.relative_to(<const Url&>dereference((<StringURL?>base).ptr))
  *         self.ptr.abspath()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def sanitize(self):
  */
-  __Pyx_TraceLine(164,0,__PYX_ERR(1, 164, __pyx_L1_error))
+  __Pyx_TraceLine(176,0,__PYX_ERR(1, 176, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":155
+  /* "url/url.pyx":167
  *             return other.relative_to(self)
  * 
  *     def relative_to(self, base):             # <<<<<<<<<<<<<<
@@ -5295,7 +5615,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3ur
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_4);
   __Pyx_XDECREF(__pyx_t_5);
-  __Pyx_AddTraceback("url.url.URL.relative_to", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.relative_to", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5304,7 +5624,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3ur
   return __pyx_r;
 }
 
-/* "url/url.pyx":166
+/* "url/url.pyx":178
  *         return self
  * 
  *     def sanitize(self):             # <<<<<<<<<<<<<<
@@ -5313,50 +5633,50 @@ static PyObject *__pyx_pf_3url_3url_3URL_28relative_to(struct __pyx_obj_3url_3ur
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_31sanitize(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_30sanitize[] = "A shortcut to abspath and escape";
-static PyObject *__pyx_pw_3url_3url_3URL_31sanitize(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_35sanitize(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_34sanitize[] = "A shortcut to abspath and escape";
+static PyObject *__pyx_pw_3url_3url_9StringURL_35sanitize(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("sanitize (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_30sanitize(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_34sanitize(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_30sanitize(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_34sanitize(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("sanitize", 0);
-  __Pyx_TraceCall("sanitize", __pyx_f[1], 166, 0, __PYX_ERR(1, 166, __pyx_L1_error));
+  __Pyx_TraceCall("sanitize", __pyx_f[1], 178, 0, __PYX_ERR(1, 178, __pyx_L1_error));
 
-  /* "url/url.pyx":168
+  /* "url/url.pyx":180
  *     def sanitize(self):
  *         '''A shortcut to abspath and escape'''
  *         self.ptr.abspath().escape(False)             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(168,0,__PYX_ERR(1, 168, __pyx_L1_error))
+  __Pyx_TraceLine(180,0,__PYX_ERR(1, 180, __pyx_L1_error))
   __pyx_v_self->ptr->abspath().escape(0);
 
-  /* "url/url.pyx":169
+  /* "url/url.pyx":181
  *         '''A shortcut to abspath and escape'''
  *         self.ptr.abspath().escape(False)
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def remove_default_port(self):
  */
-  __Pyx_TraceLine(169,0,__PYX_ERR(1, 169, __pyx_L1_error))
+  __Pyx_TraceLine(181,0,__PYX_ERR(1, 181, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":166
+  /* "url/url.pyx":178
  *         return self
  * 
  *     def sanitize(self):             # <<<<<<<<<<<<<<
@@ -5366,7 +5686,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_30sanitize(struct __pyx_obj_3url_3url_U
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.sanitize", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.sanitize", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5375,7 +5695,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_30sanitize(struct __pyx_obj_3url_3url_U
   return __pyx_r;
 }
 
-/* "url/url.pyx":171
+/* "url/url.pyx":183
  *         return self
  * 
  *     def remove_default_port(self):             # <<<<<<<<<<<<<<
@@ -5384,50 +5704,50 @@ static PyObject *__pyx_pf_3url_3url_3URL_30sanitize(struct __pyx_obj_3url_3url_U
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_33remove_default_port(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_32remove_default_port[] = "If a port is provided and is the default, remove it.";
-static PyObject *__pyx_pw_3url_3url_3URL_33remove_default_port(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_37remove_default_port(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_36remove_default_port[] = "If a port is provided and is the default, remove it.";
+static PyObject *__pyx_pw_3url_3url_9StringURL_37remove_default_port(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("remove_default_port (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_32remove_default_port(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_36remove_default_port(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_32remove_default_port(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_36remove_default_port(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("remove_default_port", 0);
-  __Pyx_TraceCall("remove_default_port", __pyx_f[1], 171, 0, __PYX_ERR(1, 171, __pyx_L1_error));
+  __Pyx_TraceCall("remove_default_port", __pyx_f[1], 183, 0, __PYX_ERR(1, 183, __pyx_L1_error));
 
-  /* "url/url.pyx":173
+  /* "url/url.pyx":185
  *     def remove_default_port(self):
  *         '''If a port is provided and is the default, remove it.'''
  *         self.ptr.remove_default_port()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(173,0,__PYX_ERR(1, 173, __pyx_L1_error))
+  __Pyx_TraceLine(185,0,__PYX_ERR(1, 185, __pyx_L1_error))
   __pyx_v_self->ptr->remove_default_port();
 
-  /* "url/url.pyx":174
+  /* "url/url.pyx":186
  *         '''If a port is provided and is the default, remove it.'''
  *         self.ptr.remove_default_port()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def escape(self, strict=False):
  */
-  __Pyx_TraceLine(174,0,__PYX_ERR(1, 174, __pyx_L1_error))
+  __Pyx_TraceLine(186,0,__PYX_ERR(1, 186, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":171
+  /* "url/url.pyx":183
  *         return self
  * 
  *     def remove_default_port(self):             # <<<<<<<<<<<<<<
@@ -5437,7 +5757,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_32remove_default_port(struct __pyx_obj_
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.remove_default_port", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.remove_default_port", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5446,7 +5766,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_32remove_default_port(struct __pyx_obj_
   return __pyx_r;
 }
 
-/* "url/url.pyx":176
+/* "url/url.pyx":188
  *         return self
  * 
  *     def escape(self, strict=False):             # <<<<<<<<<<<<<<
@@ -5455,9 +5775,9 @@ static PyObject *__pyx_pf_3url_3url_3URL_32remove_default_port(struct __pyx_obj_
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_35escape(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
-static char __pyx_doc_3url_3url_3URL_34escape[] = "Make sure that the path is correctly escaped";
-static PyObject *__pyx_pw_3url_3url_3URL_35escape(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_39escape(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_38escape[] = "Make sure that the path is correctly escaped";
+static PyObject *__pyx_pw_3url_3url_9StringURL_39escape(PyObject *__pyx_v_self, PyObject *__pyx_args, PyObject *__pyx_kwds) {
   PyObject *__pyx_v_strict = 0;
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
@@ -5483,7 +5803,7 @@ static PyObject *__pyx_pw_3url_3url_3URL_35escape(PyObject *__pyx_v_self, PyObje
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "escape") < 0)) __PYX_ERR(1, 176, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "escape") < 0)) __PYX_ERR(1, 188, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -5496,52 +5816,52 @@ static PyObject *__pyx_pw_3url_3url_3URL_35escape(PyObject *__pyx_v_self, PyObje
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("escape", 0, 0, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 176, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("escape", 0, 0, 1, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(1, 188, __pyx_L3_error)
   __pyx_L3_error:;
-  __Pyx_AddTraceback("url.url.URL.escape", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.escape", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  __pyx_r = __pyx_pf_3url_3url_3URL_34escape(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), __pyx_v_strict);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_38escape(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), __pyx_v_strict);
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_34escape(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_strict) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_38escape(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_strict) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   bool __pyx_t_1;
   __Pyx_RefNannySetupContext("escape", 0);
-  __Pyx_TraceCall("escape", __pyx_f[1], 176, 0, __PYX_ERR(1, 176, __pyx_L1_error));
+  __Pyx_TraceCall("escape", __pyx_f[1], 188, 0, __PYX_ERR(1, 188, __pyx_L1_error));
 
-  /* "url/url.pyx":178
+  /* "url/url.pyx":190
  *     def escape(self, strict=False):
  *         '''Make sure that the path is correctly escaped'''
  *         self.ptr.escape(<bool>strict)             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(178,0,__PYX_ERR(1, 178, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_v_strict); if (unlikely((__pyx_t_1 == (bool)-1) && PyErr_Occurred())) __PYX_ERR(1, 178, __pyx_L1_error)
+  __Pyx_TraceLine(190,0,__PYX_ERR(1, 190, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyObject_IsTrue(__pyx_v_strict); if (unlikely((__pyx_t_1 == (bool)-1) && PyErr_Occurred())) __PYX_ERR(1, 190, __pyx_L1_error)
   __pyx_v_self->ptr->escape(((bool)__pyx_t_1));
 
-  /* "url/url.pyx":179
+  /* "url/url.pyx":191
  *         '''Make sure that the path is correctly escaped'''
  *         self.ptr.escape(<bool>strict)
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def unescape(self):
  */
-  __Pyx_TraceLine(179,0,__PYX_ERR(1, 179, __pyx_L1_error))
+  __Pyx_TraceLine(191,0,__PYX_ERR(1, 191, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":176
+  /* "url/url.pyx":188
  *         return self
  * 
  *     def escape(self, strict=False):             # <<<<<<<<<<<<<<
@@ -5551,7 +5871,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_34escape(struct __pyx_obj_3url_3url_URL
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.escape", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.escape", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5560,7 +5880,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_34escape(struct __pyx_obj_3url_3url_URL
   return __pyx_r;
 }
 
-/* "url/url.pyx":181
+/* "url/url.pyx":193
  *         return self
  * 
  *     def unescape(self):             # <<<<<<<<<<<<<<
@@ -5569,50 +5889,50 @@ static PyObject *__pyx_pf_3url_3url_3URL_34escape(struct __pyx_obj_3url_3url_URL
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_37unescape(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_36unescape[] = "Replace entities with their corresponding byte values";
-static PyObject *__pyx_pw_3url_3url_3URL_37unescape(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_41unescape(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_40unescape[] = "Replace entities with their corresponding byte values";
+static PyObject *__pyx_pw_3url_3url_9StringURL_41unescape(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("unescape (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_36unescape(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_40unescape(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_36unescape(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_40unescape(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("unescape", 0);
-  __Pyx_TraceCall("unescape", __pyx_f[1], 181, 0, __PYX_ERR(1, 181, __pyx_L1_error));
+  __Pyx_TraceCall("unescape", __pyx_f[1], 193, 0, __PYX_ERR(1, 193, __pyx_L1_error));
 
-  /* "url/url.pyx":183
+  /* "url/url.pyx":195
  *     def unescape(self):
  *         '''Replace entities with their corresponding byte values'''
  *         self.ptr.unescape()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(183,0,__PYX_ERR(1, 183, __pyx_L1_error))
+  __Pyx_TraceLine(195,0,__PYX_ERR(1, 195, __pyx_L1_error))
   __pyx_v_self->ptr->unescape();
 
-  /* "url/url.pyx":184
+  /* "url/url.pyx":196
  *         '''Replace entities with their corresponding byte values'''
  *         self.ptr.unescape()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def encode(self, encoding):
  */
-  __Pyx_TraceLine(184,0,__PYX_ERR(1, 184, __pyx_L1_error))
+  __Pyx_TraceLine(196,0,__PYX_ERR(1, 196, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":181
+  /* "url/url.pyx":193
  *         return self
  * 
  *     def unescape(self):             # <<<<<<<<<<<<<<
@@ -5622,7 +5942,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_36unescape(struct __pyx_obj_3url_3url_U
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.unescape", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.unescape", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5631,7 +5951,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_36unescape(struct __pyx_obj_3url_3url_U
   return __pyx_r;
 }
 
-/* "url/url.pyx":186
+/* "url/url.pyx":198
  *         return self
  * 
  *     def encode(self, encoding):             # <<<<<<<<<<<<<<
@@ -5640,20 +5960,20 @@ static PyObject *__pyx_pf_3url_3url_3URL_36unescape(struct __pyx_obj_3url_3url_U
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_39encode(PyObject *__pyx_v_self, PyObject *__pyx_v_encoding); /*proto*/
-static char __pyx_doc_3url_3url_3URL_38encode[] = "Return the url in an arbitrary encoding";
-static PyObject *__pyx_pw_3url_3url_3URL_39encode(PyObject *__pyx_v_self, PyObject *__pyx_v_encoding) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_43encode(PyObject *__pyx_v_self, PyObject *__pyx_v_encoding); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_42encode[] = "Return the url in an arbitrary encoding";
+static PyObject *__pyx_pw_3url_3url_9StringURL_43encode(PyObject *__pyx_v_self, PyObject *__pyx_v_encoding) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("encode (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_38encode(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self), ((PyObject *)__pyx_v_encoding));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_42encode(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self), ((PyObject *)__pyx_v_encoding));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL *__pyx_v_self, PyObject *__pyx_v_encoding) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_42encode(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self, PyObject *__pyx_v_encoding) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
@@ -5664,43 +5984,43 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
   PyObject *__pyx_t_5 = NULL;
   PyObject *__pyx_t_6 = NULL;
   __Pyx_RefNannySetupContext("encode", 0);
-  __Pyx_TraceCall("encode", __pyx_f[1], 186, 0, __PYX_ERR(1, 186, __pyx_L1_error));
+  __Pyx_TraceCall("encode", __pyx_f[1], 198, 0, __PYX_ERR(1, 198, __pyx_L1_error));
 
-  /* "url/url.pyx":188
+  /* "url/url.pyx":200
  *     def encode(self, encoding):
  *         '''Return the url in an arbitrary encoding'''
  *         if encoding == 'utf-8' or encoding == 'utf8':             # <<<<<<<<<<<<<<
  *             return self.ptr.str()
  *         else:
  */
-  __Pyx_TraceLine(188,0,__PYX_ERR(1, 188, __pyx_L1_error))
-  __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_encoding, __pyx_kp_s_utf_8, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 188, __pyx_L1_error)
+  __Pyx_TraceLine(200,0,__PYX_ERR(1, 200, __pyx_L1_error))
+  __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_encoding, __pyx_kp_s_utf_8, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 200, __pyx_L1_error)
   if (!__pyx_t_2) {
   } else {
     __pyx_t_1 = __pyx_t_2;
     goto __pyx_L4_bool_binop_done;
   }
-  __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_encoding, __pyx_n_s_utf8, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 188, __pyx_L1_error)
+  __pyx_t_2 = (__Pyx_PyString_Equals(__pyx_v_encoding, __pyx_n_s_utf8, Py_EQ)); if (unlikely(__pyx_t_2 < 0)) __PYX_ERR(1, 200, __pyx_L1_error)
   __pyx_t_1 = __pyx_t_2;
   __pyx_L4_bool_binop_done:;
   if (__pyx_t_1) {
 
-    /* "url/url.pyx":189
+    /* "url/url.pyx":201
  *         '''Return the url in an arbitrary encoding'''
  *         if encoding == 'utf-8' or encoding == 'utf8':
  *             return self.ptr.str()             # <<<<<<<<<<<<<<
  *         else:
  *             return self.ptr.str().decode('utf-8').encode(encoding)
  */
-    __Pyx_TraceLine(189,0,__PYX_ERR(1, 189, __pyx_L1_error))
+    __Pyx_TraceLine(201,0,__PYX_ERR(1, 201, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_3 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->str()); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 189, __pyx_L1_error)
+    __pyx_t_3 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->str()); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 201, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = __pyx_t_3;
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":188
+    /* "url/url.pyx":200
  *     def encode(self, encoding):
  *         '''Return the url in an arbitrary encoding'''
  *         if encoding == 'utf-8' or encoding == 'utf8':             # <<<<<<<<<<<<<<
@@ -5709,19 +6029,19 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
  */
   }
 
-  /* "url/url.pyx":191
+  /* "url/url.pyx":203
  *             return self.ptr.str()
  *         else:
  *             return self.ptr.str().decode('utf-8').encode(encoding)             # <<<<<<<<<<<<<<
  * 
  *     def punycode(self):
  */
-  __Pyx_TraceLine(191,0,__PYX_ERR(1, 191, __pyx_L1_error))
+  __Pyx_TraceLine(203,0,__PYX_ERR(1, 203, __pyx_L1_error))
   /*else*/ {
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_4 = __Pyx_decode_cpp_string(__pyx_v_self->ptr->str(), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 191, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_decode_cpp_string(__pyx_v_self->ptr->str(), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 203, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_encode); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 191, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_encode); if (unlikely(!__pyx_t_5)) __PYX_ERR(1, 203, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     __pyx_t_4 = NULL;
@@ -5735,16 +6055,16 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
       }
     }
     if (!__pyx_t_4) {
-      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_encoding); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 191, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_encoding); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 203, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
     } else {
-      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 191, __pyx_L1_error)
+      __pyx_t_6 = PyTuple_New(1+1); if (unlikely(!__pyx_t_6)) __PYX_ERR(1, 203, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GIVEREF(__pyx_t_4); PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_4); __pyx_t_4 = NULL;
       __Pyx_INCREF(__pyx_v_encoding);
       __Pyx_GIVEREF(__pyx_v_encoding);
       PyTuple_SET_ITEM(__pyx_t_6, 0+1, __pyx_v_encoding);
-      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 191, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_6, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 203, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     }
@@ -5754,7 +6074,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
     goto __pyx_L0;
   }
 
-  /* "url/url.pyx":186
+  /* "url/url.pyx":198
  *         return self
  * 
  *     def encode(self, encoding):             # <<<<<<<<<<<<<<
@@ -5768,7 +6088,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
   __Pyx_XDECREF(__pyx_t_4);
   __Pyx_XDECREF(__pyx_t_5);
   __Pyx_XDECREF(__pyx_t_6);
-  __Pyx_AddTraceback("url.url.URL.encode", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.encode", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5777,7 +6097,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
   return __pyx_r;
 }
 
-/* "url/url.pyx":193
+/* "url/url.pyx":205
  *             return self.ptr.str().decode('utf-8').encode(encoding)
  * 
  *     def punycode(self):             # <<<<<<<<<<<<<<
@@ -5786,55 +6106,55 @@ static PyObject *__pyx_pf_3url_3url_3URL_38encode(struct __pyx_obj_3url_3url_URL
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_41punycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_40punycode[] = "Convert to punycode hostname";
-static PyObject *__pyx_pw_3url_3url_3URL_41punycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_45punycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_44punycode[] = "Convert to punycode hostname";
+static PyObject *__pyx_pw_3url_3url_9StringURL_45punycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("punycode (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_40punycode(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_44punycode(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_40punycode(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_44punycode(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("punycode", 0);
-  __Pyx_TraceCall("punycode", __pyx_f[1], 193, 0, __PYX_ERR(1, 193, __pyx_L1_error));
+  __Pyx_TraceCall("punycode", __pyx_f[1], 205, 0, __PYX_ERR(1, 205, __pyx_L1_error));
 
-  /* "url/url.pyx":195
+  /* "url/url.pyx":207
  *     def punycode(self):
  *         '''Convert to punycode hostname'''
  *         self.ptr.punycode()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(195,0,__PYX_ERR(1, 195, __pyx_L1_error))
+  __Pyx_TraceLine(207,0,__PYX_ERR(1, 207, __pyx_L1_error))
   try {
     __pyx_v_self->ptr->punycode();
   } catch(...) {
     try { throw; } catch(const std::exception& exn) { PyErr_SetString(__pyx_builtin_ValueError, exn.what()); } catch(...) { PyErr_SetNone(__pyx_builtin_ValueError); }
-    __PYX_ERR(1, 195, __pyx_L1_error)
+    __PYX_ERR(1, 207, __pyx_L1_error)
   }
 
-  /* "url/url.pyx":196
+  /* "url/url.pyx":208
  *         '''Convert to punycode hostname'''
  *         self.ptr.punycode()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     def unpunycode(self):
  */
-  __Pyx_TraceLine(196,0,__PYX_ERR(1, 196, __pyx_L1_error))
+  __Pyx_TraceLine(208,0,__PYX_ERR(1, 208, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":193
+  /* "url/url.pyx":205
  *             return self.ptr.str().decode('utf-8').encode(encoding)
  * 
  *     def punycode(self):             # <<<<<<<<<<<<<<
@@ -5844,7 +6164,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_40punycode(struct __pyx_obj_3url_3url_U
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.punycode", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.punycode", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5853,7 +6173,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_40punycode(struct __pyx_obj_3url_3url_U
   return __pyx_r;
 }
 
-/* "url/url.pyx":198
+/* "url/url.pyx":210
  *         return self
  * 
  *     def unpunycode(self):             # <<<<<<<<<<<<<<
@@ -5862,55 +6182,55 @@ static PyObject *__pyx_pf_3url_3url_3URL_40punycode(struct __pyx_obj_3url_3url_U
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_43unpunycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
-static char __pyx_doc_3url_3url_3URL_42unpunycode[] = "Convert to an unpunycoded hostname";
-static PyObject *__pyx_pw_3url_3url_3URL_43unpunycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_47unpunycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused); /*proto*/
+static char __pyx_doc_3url_3url_9StringURL_46unpunycode[] = "Convert to an unpunycoded hostname";
+static PyObject *__pyx_pw_3url_3url_9StringURL_47unpunycode(PyObject *__pyx_v_self, CYTHON_UNUSED PyObject *unused) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("unpunycode (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_42unpunycode(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_46unpunycode(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_42unpunycode(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_46unpunycode(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("unpunycode", 0);
-  __Pyx_TraceCall("unpunycode", __pyx_f[1], 198, 0, __PYX_ERR(1, 198, __pyx_L1_error));
+  __Pyx_TraceCall("unpunycode", __pyx_f[1], 210, 0, __PYX_ERR(1, 210, __pyx_L1_error));
 
-  /* "url/url.pyx":200
+  /* "url/url.pyx":212
  *     def unpunycode(self):
  *         '''Convert to an unpunycoded hostname'''
  *         self.ptr.unpunycode()             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __Pyx_TraceLine(200,0,__PYX_ERR(1, 200, __pyx_L1_error))
+  __Pyx_TraceLine(212,0,__PYX_ERR(1, 212, __pyx_L1_error))
   try {
     __pyx_v_self->ptr->unpunycode();
   } catch(...) {
     try { throw; } catch(const std::exception& exn) { PyErr_SetString(__pyx_builtin_ValueError, exn.what()); } catch(...) { PyErr_SetNone(__pyx_builtin_ValueError); }
-    __PYX_ERR(1, 200, __pyx_L1_error)
+    __PYX_ERR(1, 212, __pyx_L1_error)
   }
 
-  /* "url/url.pyx":201
+  /* "url/url.pyx":213
  *         '''Convert to an unpunycoded hostname'''
  *         self.ptr.unpunycode()
  *         return self             # <<<<<<<<<<<<<<
  * 
  *     ###########################################################################
  */
-  __Pyx_TraceLine(201,0,__PYX_ERR(1, 201, __pyx_L1_error))
+  __Pyx_TraceLine(213,0,__PYX_ERR(1, 213, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(((PyObject *)__pyx_v_self));
   __pyx_r = ((PyObject *)__pyx_v_self);
   goto __pyx_L0;
 
-  /* "url/url.pyx":198
+  /* "url/url.pyx":210
  *         return self
  * 
  *     def unpunycode(self):             # <<<<<<<<<<<<<<
@@ -5920,7 +6240,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_42unpunycode(struct __pyx_obj_3url_3url
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.unpunycode", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.unpunycode", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5929,62 +6249,62 @@ static PyObject *__pyx_pf_3url_3url_3URL_42unpunycode(struct __pyx_obj_3url_3url
   return __pyx_r;
 }
 
-/* "url/url.pyx":207
+/* "url/url.pyx":219
  *     ###########################################################################
  *     property hostname:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.host()
+ *             return self.host
  * 
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_8hostname_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_8hostname_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_8hostname_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_8hostname_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_8hostname___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8hostname___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_8hostname___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_8hostname___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 207, 0, __PYX_ERR(1, 207, __pyx_L1_error));
+  __Pyx_TraceCall("__get__", __pyx_f[1], 219, 0, __PYX_ERR(1, 219, __pyx_L1_error));
 
-  /* "url/url.pyx":208
+  /* "url/url.pyx":220
  *     property hostname:
  *         def __get__(self):
- *             return self.ptr.host()             # <<<<<<<<<<<<<<
+ *             return self.host             # <<<<<<<<<<<<<<
  * 
  *     property pld:
  */
-  __Pyx_TraceLine(208,0,__PYX_ERR(1, 208, __pyx_L1_error))
+  __Pyx_TraceLine(220,0,__PYX_ERR(1, 220, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->host()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 208, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_host); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 220, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "url/url.pyx":207
+  /* "url/url.pyx":219
  *     ###########################################################################
  *     property hostname:
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.host()
+ *             return self.host
  * 
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.hostname.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.hostname.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -5993,7 +6313,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_8hostname___get__(struct __pyx_obj_3url
   return __pyx_r;
 }
 
-/* "url/url.pyx":213
+/* "url/url.pyx":225
  *         '''Return the 'pay-level domain' of the url
  *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -6002,76 +6322,76 @@ static PyObject *__pyx_pf_3url_3url_3URL_8hostname___get__(struct __pyx_obj_3url
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_3pld_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_3pld_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_3pld_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_3pld_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_3pld___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_3pld___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_3pld___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 213, 0, __PYX_ERR(1, 213, __pyx_L1_error));
+  __Pyx_TraceCall("__get__", __pyx_f[1], 225, 0, __PYX_ERR(1, 225, __pyx_L1_error));
 
-  /* "url/url.pyx":214
+  /* "url/url.pyx":226
  *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
  *         def __get__(self):
  *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
  *                 return psl.getPLD(self.ptr.host())
- *             return ''
+ *             return b''
  */
-  __Pyx_TraceLine(214,0,__PYX_ERR(1, 214, __pyx_L1_error))
+  __Pyx_TraceLine(226,0,__PYX_ERR(1, 226, __pyx_L1_error))
   __pyx_t_1 = ((!(__pyx_v_self->ptr->host().empty() != 0)) != 0);
   if (__pyx_t_1) {
 
-    /* "url/url.pyx":215
+    /* "url/url.pyx":227
  *         def __get__(self):
  *             if not self.ptr.host().empty():
  *                 return psl.getPLD(self.ptr.host())             # <<<<<<<<<<<<<<
- *             return ''
+ *             return b''
  * 
  */
-    __Pyx_TraceLine(215,0,__PYX_ERR(1, 215, __pyx_L1_error))
+    __Pyx_TraceLine(227,0,__PYX_ERR(1, 227, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 215, __pyx_L1_error)
+    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __pyx_r = __pyx_t_2;
     __pyx_t_2 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":214
+    /* "url/url.pyx":226
  *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
  *         def __get__(self):
  *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
  *                 return psl.getPLD(self.ptr.host())
- *             return ''
+ *             return b''
  */
   }
 
-  /* "url/url.pyx":216
+  /* "url/url.pyx":228
  *             if not self.ptr.host().empty():
  *                 return psl.getPLD(self.ptr.host())
- *             return ''             # <<<<<<<<<<<<<<
+ *             return b''             # <<<<<<<<<<<<<<
  * 
  *     property tld:
  */
-  __Pyx_TraceLine(216,0,__PYX_ERR(1, 216, __pyx_L1_error))
+  __Pyx_TraceLine(228,0,__PYX_ERR(1, 228, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(__pyx_kp_s__5);
-  __pyx_r = __pyx_kp_s__5;
+  __Pyx_INCREF(__pyx_kp_b__6);
+  __pyx_r = __pyx_kp_b__6;
   goto __pyx_L0;
 
-  /* "url/url.pyx":213
+  /* "url/url.pyx":225
  *         '''Return the 'pay-level domain' of the url
  *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -6082,7 +6402,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_3pld___get__(struct __pyx_obj_3url_3url
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_2);
-  __Pyx_AddTraceback("url.url.URL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -6091,7 +6411,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_3pld___get__(struct __pyx_obj_3url_3url
   return __pyx_r;
 }
 
-/* "url/url.pyx":220
+/* "url/url.pyx":232
  *     property tld:
  *         '''Return the top-level domain of a url'''
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -6100,76 +6420,76 @@ static PyObject *__pyx_pf_3url_3url_3URL_3pld___get__(struct __pyx_obj_3url_3url
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_3tld_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_3tld_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_3tld_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_3tld_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_3tld___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_3tld___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_3tld___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_3tld___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
   PyObject *__pyx_t_2 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 220, 0, __PYX_ERR(1, 220, __pyx_L1_error));
+  __Pyx_TraceCall("__get__", __pyx_f[1], 232, 0, __PYX_ERR(1, 232, __pyx_L1_error));
 
-  /* "url/url.pyx":221
+  /* "url/url.pyx":233
  *         '''Return the top-level domain of a url'''
  *         def __get__(self):
  *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
  *                 return psl.getTLD(self.ptr.host())
- *             return ''
+ *             return b''
  */
-  __Pyx_TraceLine(221,0,__PYX_ERR(1, 221, __pyx_L1_error))
+  __Pyx_TraceLine(233,0,__PYX_ERR(1, 233, __pyx_L1_error))
   __pyx_t_1 = ((!(__pyx_v_self->ptr->host().empty() != 0)) != 0);
   if (__pyx_t_1) {
 
-    /* "url/url.pyx":222
+    /* "url/url.pyx":234
  *         def __get__(self):
  *             if not self.ptr.host().empty():
  *                 return psl.getTLD(self.ptr.host())             # <<<<<<<<<<<<<<
- *             return ''
+ *             return b''
  * 
  */
-    __Pyx_TraceLine(222,0,__PYX_ERR(1, 222, __pyx_L1_error))
+    __Pyx_TraceLine(234,0,__PYX_ERR(1, 234, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getTLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 222, __pyx_L1_error)
+    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getTLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 234, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __pyx_r = __pyx_t_2;
     __pyx_t_2 = 0;
     goto __pyx_L0;
 
-    /* "url/url.pyx":221
+    /* "url/url.pyx":233
  *         '''Return the top-level domain of a url'''
  *         def __get__(self):
  *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
  *                 return psl.getTLD(self.ptr.host())
- *             return ''
+ *             return b''
  */
   }
 
-  /* "url/url.pyx":223
+  /* "url/url.pyx":235
  *             if not self.ptr.host().empty():
  *                 return psl.getTLD(self.ptr.host())
- *             return ''             # <<<<<<<<<<<<<<
+ *             return b''             # <<<<<<<<<<<<<<
  * 
  *     property absolute:
  */
-  __Pyx_TraceLine(223,0,__PYX_ERR(1, 223, __pyx_L1_error))
+  __Pyx_TraceLine(235,0,__PYX_ERR(1, 235, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(__pyx_kp_s__5);
-  __pyx_r = __pyx_kp_s__5;
+  __Pyx_INCREF(__pyx_kp_b__6);
+  __pyx_r = __pyx_kp_b__6;
   goto __pyx_L0;
 
-  /* "url/url.pyx":220
+  /* "url/url.pyx":232
  *     property tld:
  *         '''Return the top-level domain of a url'''
  *         def __get__(self):             # <<<<<<<<<<<<<<
@@ -6180,165 +6500,7 @@ static PyObject *__pyx_pf_3url_3url_3URL_3tld___get__(struct __pyx_obj_3url_3url
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_2);
-  __Pyx_AddTraceback("url.url.URL.tld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_r = NULL;
-  __pyx_L0:;
-  __Pyx_XGIVEREF(__pyx_r);
-  __Pyx_TraceReturn(__pyx_r, 0);
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-/* "url/url.pyx":227
- *     property absolute:
- *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
- *         def __get__(self):             # <<<<<<<<<<<<<<
- *             if self.ptr.host().empty():
- *                 return False
- */
-
-/* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_8absolute_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_8absolute_1__get__(PyObject *__pyx_v_self) {
-  PyObject *__pyx_r = 0;
-  __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_8absolute___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
-
-  /* function exit code */
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-static PyObject *__pyx_pf_3url_3url_3URL_8absolute___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
-  PyObject *__pyx_r = NULL;
-  __Pyx_TraceDeclarations
-  __Pyx_RefNannyDeclarations
-  int __pyx_t_1;
-  __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 227, 0, __PYX_ERR(1, 227, __pyx_L1_error));
-
-  /* "url/url.pyx":228
- *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
- *         def __get__(self):
- *             if self.ptr.host().empty():             # <<<<<<<<<<<<<<
- *                 return False
- *             return True
- */
-  __Pyx_TraceLine(228,0,__PYX_ERR(1, 228, __pyx_L1_error))
-  __pyx_t_1 = (__pyx_v_self->ptr->host().empty() != 0);
-  if (__pyx_t_1) {
-
-    /* "url/url.pyx":229
- *         def __get__(self):
- *             if self.ptr.host().empty():
- *                 return False             # <<<<<<<<<<<<<<
- *             return True
- * 
- */
-    __Pyx_TraceLine(229,0,__PYX_ERR(1, 229, __pyx_L1_error))
-    __Pyx_XDECREF(__pyx_r);
-    __Pyx_INCREF(Py_False);
-    __pyx_r = Py_False;
-    goto __pyx_L0;
-
-    /* "url/url.pyx":228
- *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
- *         def __get__(self):
- *             if self.ptr.host().empty():             # <<<<<<<<<<<<<<
- *                 return False
- *             return True
- */
-  }
-
-  /* "url/url.pyx":230
- *             if self.ptr.host().empty():
- *                 return False
- *             return True             # <<<<<<<<<<<<<<
- * 
- *     property unicode:
- */
-  __Pyx_TraceLine(230,0,__PYX_ERR(1, 230, __pyx_L1_error))
-  __Pyx_XDECREF(__pyx_r);
-  __Pyx_INCREF(Py_True);
-  __pyx_r = Py_True;
-  goto __pyx_L0;
-
-  /* "url/url.pyx":227
- *     property absolute:
- *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
- *         def __get__(self):             # <<<<<<<<<<<<<<
- *             if self.ptr.host().empty():
- *                 return False
- */
-
-  /* function exit code */
-  __pyx_L1_error:;
-  __Pyx_AddTraceback("url.url.URL.absolute.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
-  __pyx_r = NULL;
-  __pyx_L0:;
-  __Pyx_XGIVEREF(__pyx_r);
-  __Pyx_TraceReturn(__pyx_r, 0);
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-/* "url/url.pyx":234
- *     property unicode:
- *         '''Return a unicode version of this url'''
- *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.str().decode('utf-8')
- * 
- */
-
-/* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_7unicode_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_7unicode_1__get__(PyObject *__pyx_v_self) {
-  PyObject *__pyx_r = 0;
-  __Pyx_RefNannyDeclarations
-  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_7unicode___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
-
-  /* function exit code */
-  __Pyx_RefNannyFinishContext();
-  return __pyx_r;
-}
-
-static PyObject *__pyx_pf_3url_3url_3URL_7unicode___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
-  PyObject *__pyx_r = NULL;
-  __Pyx_TraceDeclarations
-  __Pyx_RefNannyDeclarations
-  PyObject *__pyx_t_1 = NULL;
-  __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 234, 0, __PYX_ERR(1, 234, __pyx_L1_error));
-
-  /* "url/url.pyx":235
- *         '''Return a unicode version of this url'''
- *         def __get__(self):
- *             return self.ptr.str().decode('utf-8')             # <<<<<<<<<<<<<<
- * 
- *     property utf8:
- */
-  __Pyx_TraceLine(235,0,__PYX_ERR(1, 235, __pyx_L1_error))
-  __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __Pyx_decode_cpp_string(__pyx_v_self->ptr->str(), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 235, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_r = __pyx_t_1;
-  __pyx_t_1 = 0;
-  goto __pyx_L0;
-
-  /* "url/url.pyx":234
- *     property unicode:
- *         '''Return a unicode version of this url'''
- *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.str().decode('utf-8')
- * 
- */
-
-  /* function exit code */
-  __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.unicode.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.tld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -6348,57 +6510,1525 @@ static PyObject *__pyx_pf_3url_3url_3URL_7unicode___get__(struct __pyx_obj_3url_
 }
 
 /* "url/url.pyx":239
- *     property utf8:
- *         '''Return a utf-8 version of this url'''
+ *     property absolute:
+ *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.str()
+ *             if self.ptr.host().empty():
+ *                 return False
  */
 
 /* Python wrapper */
-static PyObject *__pyx_pw_3url_3url_3URL_4utf8_1__get__(PyObject *__pyx_v_self); /*proto*/
-static PyObject *__pyx_pw_3url_3url_3URL_4utf8_1__get__(PyObject *__pyx_v_self) {
+static PyObject *__pyx_pw_3url_3url_9StringURL_8absolute_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_8absolute_1__get__(PyObject *__pyx_v_self) {
   PyObject *__pyx_r = 0;
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
-  __pyx_r = __pyx_pf_3url_3url_3URL_4utf8___get__(((struct __pyx_obj_3url_3url_URL *)__pyx_v_self));
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_8absolute___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
 
   /* function exit code */
   __Pyx_RefNannyFinishContext();
   return __pyx_r;
 }
 
-static PyObject *__pyx_pf_3url_3url_3URL_4utf8___get__(struct __pyx_obj_3url_3url_URL *__pyx_v_self) {
+static PyObject *__pyx_pf_3url_3url_9StringURL_8absolute___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  int __pyx_t_1;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 239, 0, __PYX_ERR(1, 239, __pyx_L1_error));
+
+  /* "url/url.pyx":240
+ *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
+ *         def __get__(self):
+ *             if self.ptr.host().empty():             # <<<<<<<<<<<<<<
+ *                 return False
+ *             return True
+ */
+  __Pyx_TraceLine(240,0,__PYX_ERR(1, 240, __pyx_L1_error))
+  __pyx_t_1 = (__pyx_v_self->ptr->host().empty() != 0);
+  if (__pyx_t_1) {
+
+    /* "url/url.pyx":241
+ *         def __get__(self):
+ *             if self.ptr.host().empty():
+ *                 return False             # <<<<<<<<<<<<<<
+ *             return True
+ * 
+ */
+    __Pyx_TraceLine(241,0,__PYX_ERR(1, 241, __pyx_L1_error))
+    __Pyx_XDECREF(__pyx_r);
+    __Pyx_INCREF(Py_False);
+    __pyx_r = Py_False;
+    goto __pyx_L0;
+
+    /* "url/url.pyx":240
+ *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
+ *         def __get__(self):
+ *             if self.ptr.host().empty():             # <<<<<<<<<<<<<<
+ *                 return False
+ *             return True
+ */
+  }
+
+  /* "url/url.pyx":242
+ *             if self.ptr.host().empty():
+ *                 return False
+ *             return True             # <<<<<<<<<<<<<<
+ * 
+ *     property unicode:
+ */
+  __Pyx_TraceLine(242,0,__PYX_ERR(1, 242, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(Py_True);
+  __pyx_r = Py_True;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":239
+ *     property absolute:
+ *         '''Return True if this is a fully-qualified URL with a hostname and everything'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             if self.ptr.host().empty():
+ *                 return False
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_AddTraceback("url.url.StringURL.absolute.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":246
+ *     property unicode:
+ *         '''Return a unicode version of this url'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return self.ptr.str().decode('utf-8')
+ * 
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_7unicode_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_7unicode_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_7unicode___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_9StringURL_7unicode___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
   PyObject *__pyx_r = NULL;
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   PyObject *__pyx_t_1 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
-  __Pyx_TraceCall("__get__", __pyx_f[1], 239, 0, __PYX_ERR(1, 239, __pyx_L1_error));
+  __Pyx_TraceCall("__get__", __pyx_f[1], 246, 0, __PYX_ERR(1, 246, __pyx_L1_error));
 
-  /* "url/url.pyx":240
- *         '''Return a utf-8 version of this url'''
+  /* "url/url.pyx":247
+ *         '''Return a unicode version of this url'''
  *         def __get__(self):
- *             return self.ptr.str()             # <<<<<<<<<<<<<<
+ *             return self.ptr.str().decode('utf-8')             # <<<<<<<<<<<<<<
+ * 
+ *     property utf8:
  */
-  __Pyx_TraceLine(240,0,__PYX_ERR(1, 240, __pyx_L1_error))
+  __Pyx_TraceLine(247,0,__PYX_ERR(1, 247, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
-  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->str()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 240, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_decode_cpp_string(__pyx_v_self->ptr->str(), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 247, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
   goto __pyx_L0;
 
-  /* "url/url.pyx":239
- *     property utf8:
- *         '''Return a utf-8 version of this url'''
+  /* "url/url.pyx":246
+ *     property unicode:
+ *         '''Return a unicode version of this url'''
  *         def __get__(self):             # <<<<<<<<<<<<<<
- *             return self.ptr.str()
+ *             return self.ptr.str().decode('utf-8')
+ * 
  */
 
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_1);
-  __Pyx_AddTraceback("url.url.URL.utf8.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __Pyx_AddTraceback("url.url.StringURL.unicode.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":251
+ *     property utf8:
+ *         '''Return a utf-8 version of this url'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return self.ptr.str()
+ * 
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_9StringURL_4utf8_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_9StringURL_4utf8_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_9StringURL_4utf8___get__(((struct __pyx_obj_3url_3url_StringURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_9StringURL_4utf8___get__(struct __pyx_obj_3url_3url_StringURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 251, 0, __PYX_ERR(1, 251, __pyx_L1_error));
+
+  /* "url/url.pyx":252
+ *         '''Return a utf-8 version of this url'''
+ *         def __get__(self):
+ *             return self.ptr.str()             # <<<<<<<<<<<<<<
+ * 
+ * 
+ */
+  __Pyx_TraceLine(252,0,__PYX_ERR(1, 252, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->ptr->str()); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 252, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":251
+ *     property utf8:
+ *         '''Return a utf-8 version of this url'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return self.ptr.str()
+ * 
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.StringURL.utf8.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":258
+ *     '''A version of the URL class that deals in Unicode.'''
+ *     property scheme:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.scheme(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_6scheme_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_6scheme_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_6scheme___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_6scheme___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 258, 0, __PYX_ERR(1, 258, __pyx_L1_error));
+
+  /* "url/url.pyx":259
+ *     property scheme:
+ *         def __get__(self):
+ *             return text_type(self.ptr.scheme(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setScheme(as_bytes(s))
+ */
+  __Pyx_TraceLine(259,0,__PYX_ERR(1, 259, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 259, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->scheme()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 259, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 259, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 259, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 259, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 259, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":258
+ *     '''A version of the URL class that deals in Unicode.'''
+ *     property scheme:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.scheme(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.scheme.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":260
+ *         def __get__(self):
+ *             return text_type(self.ptr.scheme(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setScheme(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_6scheme_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_6scheme_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_6scheme_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_6scheme_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 260, 0, __PYX_ERR(1, 260, __pyx_L1_error));
+
+  /* "url/url.pyx":261
+ *             return text_type(self.ptr.scheme(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setScheme(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property host:
+ */
+  __Pyx_TraceLine(261,0,__PYX_ERR(1, 261, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 261, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 261, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setScheme(__pyx_t_2);
+
+  /* "url/url.pyx":260
+ *         def __get__(self):
+ *             return text_type(self.ptr.scheme(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setScheme(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.scheme.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":264
+ * 
+ *     property host:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.host(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_4host_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_4host_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_4host___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_4host___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 264, 0, __PYX_ERR(1, 264, __pyx_L1_error));
+
+  /* "url/url.pyx":265
+ *     property host:
+ *         def __get__(self):
+ *             return text_type(self.ptr.host(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setHost(as_bytes(s))
+ */
+  __Pyx_TraceLine(265,0,__PYX_ERR(1, 265, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 265, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->host()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 265, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 265, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 265, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 265, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 265, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":264
+ * 
+ *     property host:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.host(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.host.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":266
+ *         def __get__(self):
+ *             return text_type(self.ptr.host(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setHost(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_4host_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_4host_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_4host_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_4host_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 266, 0, __PYX_ERR(1, 266, __pyx_L1_error));
+
+  /* "url/url.pyx":267
+ *             return text_type(self.ptr.host(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setHost(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property path:
+ */
+  __Pyx_TraceLine(267,0,__PYX_ERR(1, 267, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 267, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 267, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setHost(__pyx_t_2);
+
+  /* "url/url.pyx":266
+ *         def __get__(self):
+ *             return text_type(self.ptr.host(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setHost(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.host.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":270
+ * 
+ *     property path:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.path(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_4path_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_4path_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_4path___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_4path___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 270, 0, __PYX_ERR(1, 270, __pyx_L1_error));
+
+  /* "url/url.pyx":271
+ *     property path:
+ *         def __get__(self):
+ *             return text_type(self.ptr.path(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setPath(as_bytes(s))
+ */
+  __Pyx_TraceLine(271,0,__PYX_ERR(1, 271, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 271, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->path()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 271, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 271, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 271, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 271, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 271, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":270
+ * 
+ *     property path:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.path(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.path.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":272
+ *         def __get__(self):
+ *             return text_type(self.ptr.path(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setPath(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_4path_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_4path_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_4path_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_4path_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 272, 0, __PYX_ERR(1, 272, __pyx_L1_error));
+
+  /* "url/url.pyx":273
+ *             return text_type(self.ptr.path(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setPath(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property params:
+ */
+  __Pyx_TraceLine(273,0,__PYX_ERR(1, 273, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 273, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 273, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setPath(__pyx_t_2);
+
+  /* "url/url.pyx":272
+ *         def __get__(self):
+ *             return text_type(self.ptr.path(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setPath(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.path.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":276
+ * 
+ *     property params:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.params(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_6params_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_6params_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_6params___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_6params___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 276, 0, __PYX_ERR(1, 276, __pyx_L1_error));
+
+  /* "url/url.pyx":277
+ *     property params:
+ *         def __get__(self):
+ *             return text_type(self.ptr.params(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setParams(as_bytes(s))
+ */
+  __Pyx_TraceLine(277,0,__PYX_ERR(1, 277, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 277, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->params()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 277, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 277, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 277, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 277, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 277, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":276
+ * 
+ *     property params:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.params(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.params.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":278
+ *         def __get__(self):
+ *             return text_type(self.ptr.params(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setParams(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_6params_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_6params_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_6params_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_6params_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 278, 0, __PYX_ERR(1, 278, __pyx_L1_error));
+
+  /* "url/url.pyx":279
+ *             return text_type(self.ptr.params(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setParams(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property query:
+ */
+  __Pyx_TraceLine(279,0,__PYX_ERR(1, 279, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 279, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 279, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setParams(__pyx_t_2);
+
+  /* "url/url.pyx":278
+ *         def __get__(self):
+ *             return text_type(self.ptr.params(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setParams(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.params.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":282
+ * 
+ *     property query:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.query(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_5query_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_5query_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_5query___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_5query___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 282, 0, __PYX_ERR(1, 282, __pyx_L1_error));
+
+  /* "url/url.pyx":283
+ *     property query:
+ *         def __get__(self):
+ *             return text_type(self.ptr.query(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setQuery(as_bytes(s))
+ */
+  __Pyx_TraceLine(283,0,__PYX_ERR(1, 283, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 283, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->query()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 283, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 283, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 283, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 283, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 283, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":282
+ * 
+ *     property query:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.query(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.query.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":284
+ *         def __get__(self):
+ *             return text_type(self.ptr.query(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setQuery(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_5query_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_5query_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_5query_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_5query_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 284, 0, __PYX_ERR(1, 284, __pyx_L1_error));
+
+  /* "url/url.pyx":285
+ *             return text_type(self.ptr.query(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setQuery(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property fragment:
+ */
+  __Pyx_TraceLine(285,0,__PYX_ERR(1, 285, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 285, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 285, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setQuery(__pyx_t_2);
+
+  /* "url/url.pyx":284
+ *         def __get__(self):
+ *             return text_type(self.ptr.query(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setQuery(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.query.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":288
+ * 
+ *     property fragment:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.fragment(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_8fragment_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_8fragment_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_8fragment___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_8fragment___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 288, 0, __PYX_ERR(1, 288, __pyx_L1_error));
+
+  /* "url/url.pyx":289
+ *     property fragment:
+ *         def __get__(self):
+ *             return text_type(self.ptr.fragment(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setFragment(as_bytes(s))
+ */
+  __Pyx_TraceLine(289,0,__PYX_ERR(1, 289, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 289, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->fragment()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 289, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 289, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 289, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 289, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 289, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":288
+ * 
+ *     property fragment:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.fragment(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.fragment.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":290
+ *         def __get__(self):
+ *             return text_type(self.ptr.fragment(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setFragment(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_8fragment_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_8fragment_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_8fragment_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_8fragment_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 290, 0, __PYX_ERR(1, 290, __pyx_L1_error));
+
+  /* "url/url.pyx":291
+ *             return text_type(self.ptr.fragment(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setFragment(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property userinfo:
+ */
+  __Pyx_TraceLine(291,0,__PYX_ERR(1, 291, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 291, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 291, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setFragment(__pyx_t_2);
+
+  /* "url/url.pyx":290
+ *         def __get__(self):
+ *             return text_type(self.ptr.fragment(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setFragment(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.fragment.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":294
+ * 
+ *     property userinfo:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.userinfo(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_8userinfo_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_8userinfo_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_8userinfo___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_8userinfo___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  PyObject *__pyx_t_2 = NULL;
+  PyObject *__pyx_t_3 = NULL;
+  PyObject *__pyx_t_4 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 294, 0, __PYX_ERR(1, 294, __pyx_L1_error));
+
+  /* "url/url.pyx":295
+ *     property userinfo:
+ *         def __get__(self):
+ *             return text_type(self.ptr.userinfo(), encoding='utf-8')             # <<<<<<<<<<<<<<
+ *         def __set__(self, s):
+ *             self.ptr.setUserinfo(as_bytes(s))
+ */
+  __Pyx_TraceLine(295,0,__PYX_ERR(1, 295, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 295, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_self->__pyx_base.ptr->userinfo()); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 295, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 295, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_GIVEREF(__pyx_t_2);
+  PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_2);
+  __pyx_t_2 = 0;
+  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 295, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_t_2, __pyx_n_s_encoding, __pyx_kp_s_utf_8) < 0) __PYX_ERR(1, 295, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_3, __pyx_t_2); if (unlikely(!__pyx_t_4)) __PYX_ERR(1, 295, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_4);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_r = __pyx_t_4;
+  __pyx_t_4 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":294
+ * 
+ *     property userinfo:
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             return text_type(self.ptr.userinfo(), encoding='utf-8')
+ *         def __set__(self, s):
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
+  __Pyx_XDECREF(__pyx_t_4);
+  __Pyx_AddTraceback("url.url.UnicodeURL.userinfo.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":296
+ *         def __get__(self):
+ *             return text_type(self.ptr.userinfo(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setUserinfo(as_bytes(s))
+ * 
+ */
+
+/* Python wrapper */
+static int __pyx_pw_3url_3url_10UnicodeURL_8userinfo_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s); /*proto*/
+static int __pyx_pw_3url_3url_10UnicodeURL_8userinfo_3__set__(PyObject *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__set__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_8userinfo_2__set__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self), ((PyObject *)__pyx_v_s));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static int __pyx_pf_3url_3url_10UnicodeURL_8userinfo_2__set__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self, PyObject *__pyx_v_s) {
+  int __pyx_r;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  std::string __pyx_t_2;
+  __Pyx_RefNannySetupContext("__set__", 0);
+  __Pyx_TraceCall("__set__", __pyx_f[1], 296, 0, __PYX_ERR(1, 296, __pyx_L1_error));
+
+  /* "url/url.pyx":297
+ *             return text_type(self.ptr.userinfo(), encoding='utf-8')
+ *         def __set__(self, s):
+ *             self.ptr.setUserinfo(as_bytes(s))             # <<<<<<<<<<<<<<
+ * 
+ *     property pld:
+ */
+  __Pyx_TraceLine(297,0,__PYX_ERR(1, 297, __pyx_L1_error))
+  __pyx_t_1 = __pyx_f_3url_3url_as_bytes(__pyx_v_s); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 297, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_t_2 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 297, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_v_self->__pyx_base.ptr->setUserinfo(__pyx_t_2);
+
+  /* "url/url.pyx":296
+ *         def __get__(self):
+ *             return text_type(self.ptr.userinfo(), encoding='utf-8')
+ *         def __set__(self, s):             # <<<<<<<<<<<<<<
+ *             self.ptr.setUserinfo(as_bytes(s))
+ * 
+ */
+
+  /* function exit code */
+  __pyx_r = 0;
+  goto __pyx_L0;
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.userinfo.__set__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = -1;
+  __pyx_L0:;
+  __Pyx_TraceReturn(Py_None, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":302
+ *         '''Return the 'pay-level domain' of the url
+ *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             if not self.ptr.host().empty():
+ *                 return psl.getPLD(self.ptr.host()).decode('utf-8')
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_3pld_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_3pld_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_3pld___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  int __pyx_t_1;
+  PyObject *__pyx_t_2 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 302, 0, __PYX_ERR(1, 302, __pyx_L1_error));
+
+  /* "url/url.pyx":303
+ *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
+ *         def __get__(self):
+ *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
+ *                 return psl.getPLD(self.ptr.host()).decode('utf-8')
+ *             return u''
+ */
+  __Pyx_TraceLine(303,0,__PYX_ERR(1, 303, __pyx_L1_error))
+  __pyx_t_1 = ((!(__pyx_v_self->__pyx_base.ptr->host().empty() != 0)) != 0);
+  if (__pyx_t_1) {
+
+    /* "url/url.pyx":304
+ *         def __get__(self):
+ *             if not self.ptr.host().empty():
+ *                 return psl.getPLD(self.ptr.host()).decode('utf-8')             # <<<<<<<<<<<<<<
+ *             return u''
+ * 
+ */
+    __Pyx_TraceLine(304,0,__PYX_ERR(1, 304, __pyx_L1_error))
+    __Pyx_XDECREF(__pyx_r);
+    __pyx_t_2 = __Pyx_decode_cpp_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->__pyx_base.ptr->host()), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 304, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_2);
+    __pyx_r = __pyx_t_2;
+    __pyx_t_2 = 0;
+    goto __pyx_L0;
+
+    /* "url/url.pyx":303
+ *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
+ *         def __get__(self):
+ *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
+ *                 return psl.getPLD(self.ptr.host()).decode('utf-8')
+ *             return u''
+ */
+  }
+
+  /* "url/url.pyx":305
+ *             if not self.ptr.host().empty():
+ *                 return psl.getPLD(self.ptr.host()).decode('utf-8')
+ *             return u''             # <<<<<<<<<<<<<<
+ * 
+ *     property tld:
+ */
+  __Pyx_TraceLine(305,0,__PYX_ERR(1, 305, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(__pyx_kp_u__6);
+  __pyx_r = __pyx_kp_u__6;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":302
+ *         '''Return the 'pay-level domain' of the url
+ *             (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             if not self.ptr.host().empty():
+ *                 return psl.getPLD(self.ptr.host()).decode('utf-8')
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_AddTraceback("url.url.UnicodeURL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":309
+ *     property tld:
+ *         '''Return the top-level domain of a url'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             if not self.ptr.host().empty():
+ *                 return psl.getTLD(self.ptr.host()).decode('utf-8')
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_3tld_1__get__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_3tld_1__get__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__get__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL_3tld___get__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3tld___get__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  int __pyx_t_1;
+  PyObject *__pyx_t_2 = NULL;
+  __Pyx_RefNannySetupContext("__get__", 0);
+  __Pyx_TraceCall("__get__", __pyx_f[1], 309, 0, __PYX_ERR(1, 309, __pyx_L1_error));
+
+  /* "url/url.pyx":310
+ *         '''Return the top-level domain of a url'''
+ *         def __get__(self):
+ *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
+ *                 return psl.getTLD(self.ptr.host()).decode('utf-8')
+ *             return u''
+ */
+  __Pyx_TraceLine(310,0,__PYX_ERR(1, 310, __pyx_L1_error))
+  __pyx_t_1 = ((!(__pyx_v_self->__pyx_base.ptr->host().empty() != 0)) != 0);
+  if (__pyx_t_1) {
+
+    /* "url/url.pyx":311
+ *         def __get__(self):
+ *             if not self.ptr.host().empty():
+ *                 return psl.getTLD(self.ptr.host()).decode('utf-8')             # <<<<<<<<<<<<<<
+ *             return u''
+ * 
+ */
+    __Pyx_TraceLine(311,0,__PYX_ERR(1, 311, __pyx_L1_error))
+    __Pyx_XDECREF(__pyx_r);
+    __pyx_t_2 = __Pyx_decode_cpp_string(__pyx_v_3url_3url_psl.getTLD(__pyx_v_self->__pyx_base.ptr->host()), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 311, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_2);
+    __pyx_r = __pyx_t_2;
+    __pyx_t_2 = 0;
+    goto __pyx_L0;
+
+    /* "url/url.pyx":310
+ *         '''Return the top-level domain of a url'''
+ *         def __get__(self):
+ *             if not self.ptr.host().empty():             # <<<<<<<<<<<<<<
+ *                 return psl.getTLD(self.ptr.host()).decode('utf-8')
+ *             return u''
+ */
+  }
+
+  /* "url/url.pyx":312
+ *             if not self.ptr.host().empty():
+ *                 return psl.getTLD(self.ptr.host()).decode('utf-8')
+ *             return u''             # <<<<<<<<<<<<<<
+ * 
+ *     def __str__(self):
+ */
+  __Pyx_TraceLine(312,0,__PYX_ERR(1, 312, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __Pyx_INCREF(__pyx_kp_u__6);
+  __pyx_r = __pyx_kp_u__6;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":309
+ *     property tld:
+ *         '''Return the top-level domain of a url'''
+ *         def __get__(self):             # <<<<<<<<<<<<<<
+ *             if not self.ptr.host().empty():
+ *                 return psl.getTLD(self.ptr.host()).decode('utf-8')
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_AddTraceback("url.url.UnicodeURL.tld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
+  __pyx_r = NULL;
+  __pyx_L0:;
+  __Pyx_XGIVEREF(__pyx_r);
+  __Pyx_TraceReturn(__pyx_r, 0);
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+/* "url/url.pyx":314
+ *             return u''
+ * 
+ *     def __str__(self):             # <<<<<<<<<<<<<<
+ *         return self.unicode
+ */
+
+/* Python wrapper */
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_1__str__(PyObject *__pyx_v_self); /*proto*/
+static PyObject *__pyx_pw_3url_3url_10UnicodeURL_1__str__(PyObject *__pyx_v_self) {
+  PyObject *__pyx_r = 0;
+  __Pyx_RefNannyDeclarations
+  __Pyx_RefNannySetupContext("__str__ (wrapper)", 0);
+  __pyx_r = __pyx_pf_3url_3url_10UnicodeURL___str__(((struct __pyx_obj_3url_3url_UnicodeURL *)__pyx_v_self));
+
+  /* function exit code */
+  __Pyx_RefNannyFinishContext();
+  return __pyx_r;
+}
+
+static PyObject *__pyx_pf_3url_3url_10UnicodeURL___str__(struct __pyx_obj_3url_3url_UnicodeURL *__pyx_v_self) {
+  PyObject *__pyx_r = NULL;
+  __Pyx_TraceDeclarations
+  __Pyx_RefNannyDeclarations
+  PyObject *__pyx_t_1 = NULL;
+  __Pyx_RefNannySetupContext("__str__", 0);
+  __Pyx_TraceCall("__str__", __pyx_f[1], 314, 0, __PYX_ERR(1, 314, __pyx_L1_error));
+
+  /* "url/url.pyx":315
+ * 
+ *     def __str__(self):
+ *         return self.unicode             # <<<<<<<<<<<<<<
+ */
+  __Pyx_TraceLine(315,0,__PYX_ERR(1, 315, __pyx_L1_error))
+  __Pyx_XDECREF(__pyx_r);
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_unicode); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 315, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __pyx_r = __pyx_t_1;
+  __pyx_t_1 = 0;
+  goto __pyx_L0;
+
+  /* "url/url.pyx":314
+ *             return u''
+ * 
+ *     def __str__(self):             # <<<<<<<<<<<<<<
+ *         return self.unicode
+ */
+
+  /* function exit code */
+  __pyx_L1_error:;
+  __Pyx_XDECREF(__pyx_t_1);
+  __Pyx_AddTraceback("url.url.UnicodeURL.__str__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
   __Pyx_XGIVEREF(__pyx_r);
@@ -6955,7 +8585,7 @@ static PyObject *__pyx_convert_unordered_set_to_py_std_3a__3a_string(std::unorde
   return __pyx_r;
 }
 
-static PyObject *__pyx_tp_new_3url_3url_URL(PyTypeObject *t, PyObject *a, PyObject *k) {
+static PyObject *__pyx_tp_new_3url_3url_StringURL(PyTypeObject *t, PyObject *a, PyObject *k) {
   PyObject *o;
   if (likely((t->tp_flags & Py_TPFLAGS_IS_ABSTRACT) == 0)) {
     o = (*t->tp_alloc)(t, 0);
@@ -6963,13 +8593,13 @@ static PyObject *__pyx_tp_new_3url_3url_URL(PyTypeObject *t, PyObject *a, PyObje
     o = (PyObject *) PyBaseObject_Type.tp_new(t, __pyx_empty_tuple, 0);
   }
   if (unlikely(!o)) return 0;
-  if (unlikely(__pyx_pw_3url_3url_3URL_1__cinit__(o, a, k) < 0)) {
+  if (unlikely(__pyx_pw_3url_3url_9StringURL_1__cinit__(o, a, k) < 0)) {
     Py_DECREF(o); o = 0;
   }
   return o;
 }
 
-static void __pyx_tp_dealloc_3url_3url_URL(PyObject *o) {
+static void __pyx_tp_dealloc_3url_3url_StringURL(PyObject *o) {
   #if PY_VERSION_HEX >= 0x030400a1
   if (unlikely(Py_TYPE(o)->tp_finalize) && (!PyType_IS_GC(Py_TYPE(o)) || !_PyGC_FINALIZED(o))) {
     if (PyObject_CallFinalizerFromDealloc(o)) return;
@@ -6979,20 +8609,20 @@ static void __pyx_tp_dealloc_3url_3url_URL(PyObject *o) {
     PyObject *etype, *eval, *etb;
     PyErr_Fetch(&etype, &eval, &etb);
     ++Py_REFCNT(o);
-    __pyx_pw_3url_3url_3URL_3__dealloc__(o);
+    __pyx_pw_3url_3url_9StringURL_3__dealloc__(o);
     --Py_REFCNT(o);
     PyErr_Restore(etype, eval, etb);
   }
   (*Py_TYPE(o)->tp_free)(o);
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_scheme(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_6scheme_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_scheme(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_6scheme_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_scheme(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_scheme(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_6scheme_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_6scheme_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7000,13 +8630,13 @@ static int __pyx_setprop_3url_3url_3URL_scheme(PyObject *o, PyObject *v, CYTHON_
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_host(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_4host_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_host(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_4host_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_host(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_host(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_4host_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_4host_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7014,13 +8644,13 @@ static int __pyx_setprop_3url_3url_3URL_host(PyObject *o, PyObject *v, CYTHON_UN
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_port(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_4port_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_port(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_4port_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_port(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_port(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_4port_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_4port_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7028,13 +8658,13 @@ static int __pyx_setprop_3url_3url_3URL_port(PyObject *o, PyObject *v, CYTHON_UN
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_path(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_4path_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_path(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_4path_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_path(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_path(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_4path_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_4path_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7042,13 +8672,13 @@ static int __pyx_setprop_3url_3url_3URL_path(PyObject *o, PyObject *v, CYTHON_UN
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_params(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_6params_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_params(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_6params_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_params(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_params(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_6params_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_6params_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7056,13 +8686,13 @@ static int __pyx_setprop_3url_3url_3URL_params(PyObject *o, PyObject *v, CYTHON_
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_query(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_5query_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_query(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_5query_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_query(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_query(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_5query_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_5query_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7070,13 +8700,13 @@ static int __pyx_setprop_3url_3url_3URL_query(PyObject *o, PyObject *v, CYTHON_U
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_fragment(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_8fragment_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_fragment(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_8fragment_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_fragment(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_fragment(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_8fragment_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_8fragment_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7084,13 +8714,13 @@ static int __pyx_setprop_3url_3url_3URL_fragment(PyObject *o, PyObject *v, CYTHO
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_userinfo(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_8userinfo_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_userinfo(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_8userinfo_1__get__(o);
 }
 
-static int __pyx_setprop_3url_3url_3URL_userinfo(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+static int __pyx_setprop_3url_3url_9StringURL_userinfo(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
   if (v) {
-    return __pyx_pw_3url_3url_3URL_8userinfo_3__set__(o, v);
+    return __pyx_pw_3url_3url_9StringURL_8userinfo_3__set__(o, v);
   }
   else {
     PyErr_SetString(PyExc_NotImplementedError, "__del__");
@@ -7098,75 +8728,77 @@ static int __pyx_setprop_3url_3url_3URL_userinfo(PyObject *o, PyObject *v, CYTHO
   }
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_hostname(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_8hostname_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_hostname(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_8hostname_1__get__(o);
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_pld(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_3pld_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_pld(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_3pld_1__get__(o);
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_tld(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_3tld_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_tld(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_3tld_1__get__(o);
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_absolute(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_8absolute_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_absolute(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_8absolute_1__get__(o);
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_unicode(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_7unicode_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_unicode(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_7unicode_1__get__(o);
 }
 
-static PyObject *__pyx_getprop_3url_3url_3URL_utf8(PyObject *o, CYTHON_UNUSED void *x) {
-  return __pyx_pw_3url_3url_3URL_4utf8_1__get__(o);
+static PyObject *__pyx_getprop_3url_3url_9StringURL_utf8(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_9StringURL_4utf8_1__get__(o);
 }
 
-static PyMethodDef __pyx_methods_3url_3url_URL[] = {
-  {"copy", (PyCFunction)__pyx_pw_3url_3url_3URL_5copy, METH_NOARGS, __pyx_doc_3url_3url_3URL_4copy},
-  {"equiv", (PyCFunction)__pyx_pw_3url_3url_3URL_7equiv, METH_VARARGS|METH_KEYWORDS, __pyx_doc_3url_3url_3URL_6equiv},
-  {"canonical", (PyCFunction)__pyx_pw_3url_3url_3URL_15canonical, METH_NOARGS, 0},
-  {"defrag", (PyCFunction)__pyx_pw_3url_3url_3URL_17defrag, METH_NOARGS, __pyx_doc_3url_3url_3URL_16defrag},
-  {"deparam", (PyCFunction)__pyx_pw_3url_3url_3URL_19deparam, METH_O, __pyx_doc_3url_3url_3URL_18deparam},
-  {"filter_params", (PyCFunction)__pyx_pw_3url_3url_3URL_21filter_params, METH_O, __pyx_doc_3url_3url_3URL_20filter_params},
-  {"deuserinfo", (PyCFunction)__pyx_pw_3url_3url_3URL_23deuserinfo, METH_NOARGS, __pyx_doc_3url_3url_3URL_22deuserinfo},
-  {"abspath", (PyCFunction)__pyx_pw_3url_3url_3URL_25abspath, METH_NOARGS, __pyx_doc_3url_3url_3URL_24abspath},
-  {"relative", (PyCFunction)__pyx_pw_3url_3url_3URL_27relative, METH_O, __pyx_doc_3url_3url_3URL_26relative},
-  {"relative_to", (PyCFunction)__pyx_pw_3url_3url_3URL_29relative_to, METH_O, __pyx_doc_3url_3url_3URL_28relative_to},
-  {"sanitize", (PyCFunction)__pyx_pw_3url_3url_3URL_31sanitize, METH_NOARGS, __pyx_doc_3url_3url_3URL_30sanitize},
-  {"remove_default_port", (PyCFunction)__pyx_pw_3url_3url_3URL_33remove_default_port, METH_NOARGS, __pyx_doc_3url_3url_3URL_32remove_default_port},
-  {"escape", (PyCFunction)__pyx_pw_3url_3url_3URL_35escape, METH_VARARGS|METH_KEYWORDS, __pyx_doc_3url_3url_3URL_34escape},
-  {"unescape", (PyCFunction)__pyx_pw_3url_3url_3URL_37unescape, METH_NOARGS, __pyx_doc_3url_3url_3URL_36unescape},
-  {"encode", (PyCFunction)__pyx_pw_3url_3url_3URL_39encode, METH_O, __pyx_doc_3url_3url_3URL_38encode},
-  {"punycode", (PyCFunction)__pyx_pw_3url_3url_3URL_41punycode, METH_NOARGS, __pyx_doc_3url_3url_3URL_40punycode},
-  {"unpunycode", (PyCFunction)__pyx_pw_3url_3url_3URL_43unpunycode, METH_NOARGS, __pyx_doc_3url_3url_3URL_42unpunycode},
+static PyMethodDef __pyx_methods_3url_3url_StringURL[] = {
+  {"copy", (PyCFunction)__pyx_pw_3url_3url_9StringURL_5copy, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_4copy},
+  {"equiv", (PyCFunction)__pyx_pw_3url_3url_9StringURL_7equiv, METH_VARARGS|METH_KEYWORDS, __pyx_doc_3url_3url_9StringURL_6equiv},
+  {"__unicode__", (PyCFunction)__pyx_pw_3url_3url_9StringURL_11__unicode__, METH_NOARGS, 0},
+  {"__bytes__", (PyCFunction)__pyx_pw_3url_3url_9StringURL_15__bytes__, METH_NOARGS, 0},
+  {"canonical", (PyCFunction)__pyx_pw_3url_3url_9StringURL_19canonical, METH_NOARGS, 0},
+  {"defrag", (PyCFunction)__pyx_pw_3url_3url_9StringURL_21defrag, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_20defrag},
+  {"deparam", (PyCFunction)__pyx_pw_3url_3url_9StringURL_23deparam, METH_O, __pyx_doc_3url_3url_9StringURL_22deparam},
+  {"filter_params", (PyCFunction)__pyx_pw_3url_3url_9StringURL_25filter_params, METH_O, __pyx_doc_3url_3url_9StringURL_24filter_params},
+  {"deuserinfo", (PyCFunction)__pyx_pw_3url_3url_9StringURL_27deuserinfo, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_26deuserinfo},
+  {"abspath", (PyCFunction)__pyx_pw_3url_3url_9StringURL_29abspath, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_28abspath},
+  {"relative", (PyCFunction)__pyx_pw_3url_3url_9StringURL_31relative, METH_O, __pyx_doc_3url_3url_9StringURL_30relative},
+  {"relative_to", (PyCFunction)__pyx_pw_3url_3url_9StringURL_33relative_to, METH_O, __pyx_doc_3url_3url_9StringURL_32relative_to},
+  {"sanitize", (PyCFunction)__pyx_pw_3url_3url_9StringURL_35sanitize, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_34sanitize},
+  {"remove_default_port", (PyCFunction)__pyx_pw_3url_3url_9StringURL_37remove_default_port, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_36remove_default_port},
+  {"escape", (PyCFunction)__pyx_pw_3url_3url_9StringURL_39escape, METH_VARARGS|METH_KEYWORDS, __pyx_doc_3url_3url_9StringURL_38escape},
+  {"unescape", (PyCFunction)__pyx_pw_3url_3url_9StringURL_41unescape, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_40unescape},
+  {"encode", (PyCFunction)__pyx_pw_3url_3url_9StringURL_43encode, METH_O, __pyx_doc_3url_3url_9StringURL_42encode},
+  {"punycode", (PyCFunction)__pyx_pw_3url_3url_9StringURL_45punycode, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_44punycode},
+  {"unpunycode", (PyCFunction)__pyx_pw_3url_3url_9StringURL_47unpunycode, METH_NOARGS, __pyx_doc_3url_3url_9StringURL_46unpunycode},
   {0, 0, 0, 0}
 };
 
-static struct PyGetSetDef __pyx_getsets_3url_3url_URL[] = {
-  {(char *)"scheme", __pyx_getprop_3url_3url_3URL_scheme, __pyx_setprop_3url_3url_3URL_scheme, (char *)0, 0},
-  {(char *)"host", __pyx_getprop_3url_3url_3URL_host, __pyx_setprop_3url_3url_3URL_host, (char *)0, 0},
-  {(char *)"port", __pyx_getprop_3url_3url_3URL_port, __pyx_setprop_3url_3url_3URL_port, (char *)0, 0},
-  {(char *)"path", __pyx_getprop_3url_3url_3URL_path, __pyx_setprop_3url_3url_3URL_path, (char *)0, 0},
-  {(char *)"params", __pyx_getprop_3url_3url_3URL_params, __pyx_setprop_3url_3url_3URL_params, (char *)0, 0},
-  {(char *)"query", __pyx_getprop_3url_3url_3URL_query, __pyx_setprop_3url_3url_3URL_query, (char *)0, 0},
-  {(char *)"fragment", __pyx_getprop_3url_3url_3URL_fragment, __pyx_setprop_3url_3url_3URL_fragment, (char *)0, 0},
-  {(char *)"userinfo", __pyx_getprop_3url_3url_3URL_userinfo, __pyx_setprop_3url_3url_3URL_userinfo, (char *)0, 0},
-  {(char *)"hostname", __pyx_getprop_3url_3url_3URL_hostname, 0, (char *)0, 0},
-  {(char *)"pld", __pyx_getprop_3url_3url_3URL_pld, 0, (char *)"Return the 'pay-level domain' of the url\n            (http://moz.com/blog/what-the-heck-should-we-call-domaincom)", 0},
-  {(char *)"tld", __pyx_getprop_3url_3url_3URL_tld, 0, (char *)"Return the top-level domain of a url", 0},
-  {(char *)"absolute", __pyx_getprop_3url_3url_3URL_absolute, 0, (char *)"Return True if this is a fully-qualified URL with a hostname and everything", 0},
-  {(char *)"unicode", __pyx_getprop_3url_3url_3URL_unicode, 0, (char *)"Return a unicode version of this url", 0},
-  {(char *)"utf8", __pyx_getprop_3url_3url_3URL_utf8, 0, (char *)"Return a utf-8 version of this url", 0},
+static struct PyGetSetDef __pyx_getsets_3url_3url_StringURL[] = {
+  {(char *)"scheme", __pyx_getprop_3url_3url_9StringURL_scheme, __pyx_setprop_3url_3url_9StringURL_scheme, (char *)0, 0},
+  {(char *)"host", __pyx_getprop_3url_3url_9StringURL_host, __pyx_setprop_3url_3url_9StringURL_host, (char *)0, 0},
+  {(char *)"port", __pyx_getprop_3url_3url_9StringURL_port, __pyx_setprop_3url_3url_9StringURL_port, (char *)0, 0},
+  {(char *)"path", __pyx_getprop_3url_3url_9StringURL_path, __pyx_setprop_3url_3url_9StringURL_path, (char *)0, 0},
+  {(char *)"params", __pyx_getprop_3url_3url_9StringURL_params, __pyx_setprop_3url_3url_9StringURL_params, (char *)0, 0},
+  {(char *)"query", __pyx_getprop_3url_3url_9StringURL_query, __pyx_setprop_3url_3url_9StringURL_query, (char *)0, 0},
+  {(char *)"fragment", __pyx_getprop_3url_3url_9StringURL_fragment, __pyx_setprop_3url_3url_9StringURL_fragment, (char *)0, 0},
+  {(char *)"userinfo", __pyx_getprop_3url_3url_9StringURL_userinfo, __pyx_setprop_3url_3url_9StringURL_userinfo, (char *)0, 0},
+  {(char *)"hostname", __pyx_getprop_3url_3url_9StringURL_hostname, 0, (char *)0, 0},
+  {(char *)"pld", __pyx_getprop_3url_3url_9StringURL_pld, 0, (char *)"Return the 'pay-level domain' of the url\n            (http://moz.com/blog/what-the-heck-should-we-call-domaincom)", 0},
+  {(char *)"tld", __pyx_getprop_3url_3url_9StringURL_tld, 0, (char *)"Return the top-level domain of a url", 0},
+  {(char *)"absolute", __pyx_getprop_3url_3url_9StringURL_absolute, 0, (char *)"Return True if this is a fully-qualified URL with a hostname and everything", 0},
+  {(char *)"unicode", __pyx_getprop_3url_3url_9StringURL_unicode, 0, (char *)"Return a unicode version of this url", 0},
+  {(char *)"utf8", __pyx_getprop_3url_3url_9StringURL_utf8, 0, (char *)"Return a utf-8 version of this url", 0},
   {0, 0, 0, 0, 0}
 };
 
-static PyTypeObject __pyx_type_3url_3url_URL = {
+static PyTypeObject __pyx_type_3url_3url_StringURL = {
   PyVarObject_HEAD_INIT(0, 0)
-  "url.url.URL", /*tp_name*/
-  sizeof(struct __pyx_obj_3url_3url_URL), /*tp_basicsize*/
+  "url.url.StringURL", /*tp_name*/
+  sizeof(struct __pyx_obj_3url_3url_StringURL), /*tp_basicsize*/
   0, /*tp_itemsize*/
-  __pyx_tp_dealloc_3url_3url_URL, /*tp_dealloc*/
+  __pyx_tp_dealloc_3url_3url_StringURL, /*tp_dealloc*/
   0, /*tp_print*/
   0, /*tp_getattr*/
   0, /*tp_setattr*/
@@ -7176,27 +8808,27 @@ static PyTypeObject __pyx_type_3url_3url_URL = {
   #if PY_MAJOR_VERSION >= 3
   0, /*tp_as_async*/
   #endif
-  __pyx_pw_3url_3url_3URL_13__repr__, /*tp_repr*/
+  __pyx_pw_3url_3url_9StringURL_17__repr__, /*tp_repr*/
   0, /*tp_as_number*/
   0, /*tp_as_sequence*/
   0, /*tp_as_mapping*/
   0, /*tp_hash*/
   0, /*tp_call*/
-  __pyx_pw_3url_3url_3URL_11__str__, /*tp_str*/
+  __pyx_pw_3url_3url_9StringURL_13__str__, /*tp_str*/
   0, /*tp_getattro*/
   0, /*tp_setattro*/
   0, /*tp_as_buffer*/
   Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_VERSION_TAG|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_NEWBUFFER|Py_TPFLAGS_BASETYPE, /*tp_flags*/
-  "Wrapper around url-cpp.", /*tp_doc*/
+  "Wrapper around url-cpp, which deals in strings.", /*tp_doc*/
   0, /*tp_traverse*/
   0, /*tp_clear*/
-  __pyx_pw_3url_3url_3URL_9__richcmp__, /*tp_richcompare*/
+  __pyx_pw_3url_3url_9StringURL_9__richcmp__, /*tp_richcompare*/
   0, /*tp_weaklistoffset*/
   0, /*tp_iter*/
   0, /*tp_iternext*/
-  __pyx_methods_3url_3url_URL, /*tp_methods*/
+  __pyx_methods_3url_3url_StringURL, /*tp_methods*/
   0, /*tp_members*/
-  __pyx_getsets_3url_3url_URL, /*tp_getset*/
+  __pyx_getsets_3url_3url_StringURL, /*tp_getset*/
   0, /*tp_base*/
   0, /*tp_dict*/
   0, /*tp_descr_get*/
@@ -7204,7 +8836,198 @@ static PyTypeObject __pyx_type_3url_3url_URL = {
   0, /*tp_dictoffset*/
   0, /*tp_init*/
   0, /*tp_alloc*/
-  __pyx_tp_new_3url_3url_URL, /*tp_new*/
+  __pyx_tp_new_3url_3url_StringURL, /*tp_new*/
+  0, /*tp_free*/
+  0, /*tp_is_gc*/
+  0, /*tp_bases*/
+  0, /*tp_mro*/
+  0, /*tp_cache*/
+  0, /*tp_subclasses*/
+  0, /*tp_weaklist*/
+  0, /*tp_del*/
+  0, /*tp_version_tag*/
+  #if PY_VERSION_HEX >= 0x030400a1
+  0, /*tp_finalize*/
+  #endif
+};
+
+static PyObject *__pyx_tp_new_3url_3url_UnicodeURL(PyTypeObject *t, PyObject *a, PyObject *k) {
+  PyObject *o = __pyx_tp_new_3url_3url_StringURL(t, a, k);
+  if (unlikely(!o)) return 0;
+  return o;
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_scheme(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_6scheme_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_scheme(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_6scheme_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_host(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_4host_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_host(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_4host_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_path(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_4path_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_path(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_4path_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_params(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_6params_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_params(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_6params_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_query(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_5query_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_query(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_5query_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_fragment(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_8fragment_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_fragment(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_8fragment_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_userinfo(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_8userinfo_1__get__(o);
+}
+
+static int __pyx_setprop_3url_3url_10UnicodeURL_userinfo(PyObject *o, PyObject *v, CYTHON_UNUSED void *x) {
+  if (v) {
+    return __pyx_pw_3url_3url_10UnicodeURL_8userinfo_3__set__(o, v);
+  }
+  else {
+    PyErr_SetString(PyExc_NotImplementedError, "__del__");
+    return -1;
+  }
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_pld(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_3pld_1__get__(o);
+}
+
+static PyObject *__pyx_getprop_3url_3url_10UnicodeURL_tld(PyObject *o, CYTHON_UNUSED void *x) {
+  return __pyx_pw_3url_3url_10UnicodeURL_3tld_1__get__(o);
+}
+
+static PyMethodDef __pyx_methods_3url_3url_UnicodeURL[] = {
+  {0, 0, 0, 0}
+};
+
+static struct PyGetSetDef __pyx_getsets_3url_3url_UnicodeURL[] = {
+  {(char *)"scheme", __pyx_getprop_3url_3url_10UnicodeURL_scheme, __pyx_setprop_3url_3url_10UnicodeURL_scheme, (char *)0, 0},
+  {(char *)"host", __pyx_getprop_3url_3url_10UnicodeURL_host, __pyx_setprop_3url_3url_10UnicodeURL_host, (char *)0, 0},
+  {(char *)"path", __pyx_getprop_3url_3url_10UnicodeURL_path, __pyx_setprop_3url_3url_10UnicodeURL_path, (char *)0, 0},
+  {(char *)"params", __pyx_getprop_3url_3url_10UnicodeURL_params, __pyx_setprop_3url_3url_10UnicodeURL_params, (char *)0, 0},
+  {(char *)"query", __pyx_getprop_3url_3url_10UnicodeURL_query, __pyx_setprop_3url_3url_10UnicodeURL_query, (char *)0, 0},
+  {(char *)"fragment", __pyx_getprop_3url_3url_10UnicodeURL_fragment, __pyx_setprop_3url_3url_10UnicodeURL_fragment, (char *)0, 0},
+  {(char *)"userinfo", __pyx_getprop_3url_3url_10UnicodeURL_userinfo, __pyx_setprop_3url_3url_10UnicodeURL_userinfo, (char *)0, 0},
+  {(char *)"pld", __pyx_getprop_3url_3url_10UnicodeURL_pld, 0, (char *)"Return the 'pay-level domain' of the url\n            (http://moz.com/blog/what-the-heck-should-we-call-domaincom)", 0},
+  {(char *)"tld", __pyx_getprop_3url_3url_10UnicodeURL_tld, 0, (char *)"Return the top-level domain of a url", 0},
+  {0, 0, 0, 0, 0}
+};
+
+static PyTypeObject __pyx_type_3url_3url_UnicodeURL = {
+  PyVarObject_HEAD_INIT(0, 0)
+  "url.url.UnicodeURL", /*tp_name*/
+  sizeof(struct __pyx_obj_3url_3url_UnicodeURL), /*tp_basicsize*/
+  0, /*tp_itemsize*/
+  __pyx_tp_dealloc_3url_3url_StringURL, /*tp_dealloc*/
+  0, /*tp_print*/
+  0, /*tp_getattr*/
+  0, /*tp_setattr*/
+  #if PY_MAJOR_VERSION < 3
+  0, /*tp_compare*/
+  #endif
+  #if PY_MAJOR_VERSION >= 3
+  0, /*tp_as_async*/
+  #endif
+  #if CYTHON_COMPILING_IN_PYPY
+  __pyx_pw_3url_3url_9StringURL_17__repr__, /*tp_repr*/
+  #else
+  0, /*tp_repr*/
+  #endif
+  0, /*tp_as_number*/
+  0, /*tp_as_sequence*/
+  0, /*tp_as_mapping*/
+  0, /*tp_hash*/
+  0, /*tp_call*/
+  __pyx_pw_3url_3url_10UnicodeURL_1__str__, /*tp_str*/
+  0, /*tp_getattro*/
+  0, /*tp_setattro*/
+  0, /*tp_as_buffer*/
+  Py_TPFLAGS_DEFAULT|Py_TPFLAGS_HAVE_VERSION_TAG|Py_TPFLAGS_CHECKTYPES|Py_TPFLAGS_HAVE_NEWBUFFER|Py_TPFLAGS_BASETYPE, /*tp_flags*/
+  "A version of the URL class that deals in Unicode.", /*tp_doc*/
+  0, /*tp_traverse*/
+  0, /*tp_clear*/
+  0, /*tp_richcompare*/
+  0, /*tp_weaklistoffset*/
+  0, /*tp_iter*/
+  0, /*tp_iternext*/
+  __pyx_methods_3url_3url_UnicodeURL, /*tp_methods*/
+  0, /*tp_members*/
+  __pyx_getsets_3url_3url_UnicodeURL, /*tp_getset*/
+  0, /*tp_base*/
+  0, /*tp_dict*/
+  0, /*tp_descr_get*/
+  0, /*tp_descr_set*/
+  0, /*tp_dictoffset*/
+  0, /*tp_init*/
+  0, /*tp_alloc*/
+  __pyx_tp_new_3url_3url_UnicodeURL, /*tp_new*/
   0, /*tp_free*/
   0, /*tp_is_gc*/
   0, /*tp_bases*/
@@ -7496,7 +9319,7 @@ static int __pyx_tp_clear_3url_3url___pyx_scope_struct_2_filter_params(PyObject 
   p->__pyx_v_keep = Py_None; Py_INCREF(Py_None);
   Py_XDECREF(tmp);
   tmp = ((PyObject*)p->__pyx_v_self);
-  p->__pyx_v_self = ((struct __pyx_obj_3url_3url_URL *)Py_None); Py_INCREF(Py_None);
+  p->__pyx_v_self = ((struct __pyx_obj_3url_3url_StringURL *)Py_None); Py_INCREF(Py_None);
   Py_XDECREF(tmp);
   return 0;
 }
@@ -7821,11 +9644,12 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_NotImplementedError, __pyx_k_NotImplementedError, sizeof(__pyx_k_NotImplementedError), 0, 0, 1, 1},
   {&__pyx_n_s_ParseMethod, __pyx_k_ParseMethod, sizeof(__pyx_k_ParseMethod), 0, 0, 1, 1},
   {&__pyx_n_s_ValueError, __pyx_k_ValueError, sizeof(__pyx_k_ValueError), 0, 0, 1, 1},
-  {&__pyx_kp_s__11, __pyx_k__11, sizeof(__pyx_k__11), 0, 0, 1, 0},
-  {&__pyx_n_s__13, __pyx_k__13, sizeof(__pyx_k__13), 0, 0, 1, 1},
-  {&__pyx_kp_s__5, __pyx_k__5, sizeof(__pyx_k__5), 0, 0, 1, 0},
-  {&__pyx_kp_s__7, __pyx_k__7, sizeof(__pyx_k__7), 0, 0, 1, 0},
-  {&__pyx_kp_s__9, __pyx_k__9, sizeof(__pyx_k__9), 0, 0, 1, 0},
+  {&__pyx_kp_s__10, __pyx_k__10, sizeof(__pyx_k__10), 0, 0, 1, 0},
+  {&__pyx_kp_s__12, __pyx_k__12, sizeof(__pyx_k__12), 0, 0, 1, 0},
+  {&__pyx_n_s__14, __pyx_k__14, sizeof(__pyx_k__14), 0, 0, 1, 1},
+  {&__pyx_kp_b__6, __pyx_k__6, sizeof(__pyx_k__6), 0, 0, 0, 0},
+  {&__pyx_kp_u__6, __pyx_k__6, sizeof(__pyx_k__6), 0, 1, 0, 0},
+  {&__pyx_kp_s__8, __pyx_k__8, sizeof(__pyx_k__8), 0, 0, 1, 0},
   {&__pyx_n_s_args, __pyx_k_args, sizeof(__pyx_k_args), 0, 0, 1, 1},
   {&__pyx_n_s_close, __pyx_k_close, sizeof(__pyx_k_close), 0, 0, 1, 1},
   {&__pyx_n_s_cls, __pyx_k_cls, sizeof(__pyx_k_cls), 0, 0, 1, 1},
@@ -7839,6 +9663,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_filter_params_locals_keep, __pyx_k_filter_params_locals_keep, sizeof(__pyx_k_filter_params_locals_keep), 0, 0, 1, 1},
   {&__pyx_n_s_genexpr, __pyx_k_genexpr, sizeof(__pyx_k_genexpr), 0, 0, 1, 1},
   {&__pyx_n_s_get_data, __pyx_k_get_data, sizeof(__pyx_k_get_data), 0, 0, 1, 1},
+  {&__pyx_n_s_host, __pyx_k_host, sizeof(__pyx_k_host), 0, 0, 1, 1},
   {&__pyx_n_s_import, __pyx_k_import, sizeof(__pyx_k_import), 0, 0, 1, 1},
   {&__pyx_n_s_join, __pyx_k_join, sizeof(__pyx_k_join), 0, 0, 1, 1},
   {&__pyx_n_s_keep, __pyx_k_keep, sizeof(__pyx_k_keep), 0, 0, 1, 1},
@@ -7859,10 +9684,13 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_kp_s_s_does_not_support_this_operati, __pyx_k_s_does_not_support_this_operati, sizeof(__pyx_k_s_does_not_support_this_operati), 0, 0, 1, 0},
   {&__pyx_n_s_send, __pyx_k_send, sizeof(__pyx_k_send), 0, 0, 1, 1},
   {&__pyx_n_s_set_psl, __pyx_k_set_psl, sizeof(__pyx_k_set_psl), 0, 0, 1, 1},
+  {&__pyx_n_s_six, __pyx_k_six, sizeof(__pyx_k_six), 0, 0, 1, 1},
   {&__pyx_n_s_split, __pyx_k_split, sizeof(__pyx_k_split), 0, 0, 1, 1},
   {&__pyx_n_s_strict, __pyx_k_strict, sizeof(__pyx_k_strict), 0, 0, 1, 1},
   {&__pyx_n_s_test, __pyx_k_test, sizeof(__pyx_k_test), 0, 0, 1, 1},
+  {&__pyx_n_s_text_type, __pyx_k_text_type, sizeof(__pyx_k_text_type), 0, 0, 1, 1},
   {&__pyx_n_s_throw, __pyx_k_throw, sizeof(__pyx_k_throw), 0, 0, 1, 1},
+  {&__pyx_n_s_unicode, __pyx_k_unicode, sizeof(__pyx_k_unicode), 0, 0, 1, 1},
   {&__pyx_n_s_url, __pyx_k_url, sizeof(__pyx_k_url), 0, 0, 1, 1},
   {&__pyx_kp_s_url_URL_object_s, __pyx_k_url_URL_object_s, sizeof(__pyx_k_url_URL_object_s), 0, 0, 1, 0},
   {&__pyx_n_s_url_url, __pyx_k_url_url, sizeof(__pyx_k_url_url), 0, 0, 1, 1},
@@ -7874,7 +9702,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
 };
 static int __Pyx_InitCachedBuiltins(void) {
   __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 22, __pyx_L1_error)
-  __pyx_builtin_NotImplementedError = __Pyx_GetBuiltinName(__pyx_n_s_NotImplementedError); if (!__pyx_builtin_NotImplementedError) __PYX_ERR(1, 105, __pyx_L1_error)
+  __pyx_builtin_NotImplementedError = __Pyx_GetBuiltinName(__pyx_n_s_NotImplementedError); if (!__pyx_builtin_NotImplementedError) __PYX_ERR(1, 111, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;
   return -1;
@@ -7884,129 +9712,140 @@ static int __Pyx_InitCachedConstants(void) {
   __Pyx_RefNannyDeclarations
   __Pyx_RefNannySetupContext("__Pyx_InitCachedConstants", 0);
 
-  /* "url/url.pyx":14
+  /* "url/url.pyx":16
  *             return cls(s)
  *         else:
  *             return cls(s.decode(encoding).encode('utf-8'))             # <<<<<<<<<<<<<<
  *     else:
  *         return cls(s.encode('utf-8'))
  */
-  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(1, 14, __pyx_L1_error)
+  __pyx_tuple__2 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__2)) __PYX_ERR(1, 16, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__2);
   __Pyx_GIVEREF(__pyx_tuple__2);
 
-  /* "url/url.pyx":16
+  /* "url/url.pyx":18
  *             return cls(s.decode(encoding).encode('utf-8'))
  *     else:
  *         return cls(s.encode('utf-8'))             # <<<<<<<<<<<<<<
  * 
  * def set_psl(rules):
  */
-  __pyx_tuple__3 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(1, 16, __pyx_L1_error)
+  __pyx_tuple__3 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__3)) __PYX_ERR(1, 18, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_tuple__3);
   __Pyx_GIVEREF(__pyx_tuple__3);
 
-  /* "url/url.pyx":86
+  /* "url/url.pyx":26
+ * cdef as_bytes(obj):
+ *     if isinstance(obj, text_type):
+ *         return obj.encode('utf-8')             # <<<<<<<<<<<<<<
+ *     return obj
+ * 
+ */
+  __pyx_tuple__5 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__5)) __PYX_ERR(1, 26, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__5);
+  __Pyx_GIVEREF(__pyx_tuple__5);
+
+  /* "url/url.pyx":92
  *     def copy(self):
  *         '''Return a new instance of an identical URL.'''
- *         new = URL('')             # <<<<<<<<<<<<<<
+ *         new = StringURL(b'')             # <<<<<<<<<<<<<<
  *         new.ptr.assign(dereference(self.ptr));
  *         return new
  */
-  __pyx_tuple__6 = PyTuple_Pack(1, __pyx_kp_s__5); if (unlikely(!__pyx_tuple__6)) __PYX_ERR(1, 86, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__6);
-  __Pyx_GIVEREF(__pyx_tuple__6);
+  __pyx_tuple__7 = PyTuple_Pack(1, __pyx_kp_b__6); if (unlikely(!__pyx_tuple__7)) __PYX_ERR(1, 92, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__7);
+  __Pyx_GIVEREF(__pyx_tuple__7);
 
-  /* "url/url.pyx":132
- *         '''Remove parameters if function(name, value)'''
+  /* "url/url.pyx":144
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):
  *             name, _, value = query.partition('=')             # <<<<<<<<<<<<<<
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  */
-  __pyx_tuple__8 = PyTuple_Pack(1, __pyx_kp_s__7); if (unlikely(!__pyx_tuple__8)) __PYX_ERR(1, 132, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__8);
-  __Pyx_GIVEREF(__pyx_tuple__8);
+  __pyx_tuple__9 = PyTuple_Pack(1, __pyx_kp_s__8); if (unlikely(!__pyx_tuple__9)) __PYX_ERR(1, 144, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__9);
+  __Pyx_GIVEREF(__pyx_tuple__9);
 
-  /* "url/url.pyx":134
+  /* "url/url.pyx":146
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))             # <<<<<<<<<<<<<<
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))
  *         return self
  */
-  __pyx_tuple__10 = PyTuple_Pack(1, __pyx_kp_s__9); if (unlikely(!__pyx_tuple__10)) __PYX_ERR(1, 134, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__10);
-  __Pyx_GIVEREF(__pyx_tuple__10);
+  __pyx_tuple__11 = PyTuple_Pack(1, __pyx_kp_s__10); if (unlikely(!__pyx_tuple__11)) __PYX_ERR(1, 146, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__11);
+  __Pyx_GIVEREF(__pyx_tuple__11);
 
-  /* "url/url.pyx":135
+  /* "url/url.pyx":147
  *             return not function(name, value)
  *         self.query = '&'.join(q for q in self.query.split('&') if q and keep(q))
  *         self.params = ';'.join(q for q in self.params.split(';') if q and keep(q))             # <<<<<<<<<<<<<<
  *         return self
  * 
  */
-  __pyx_tuple__12 = PyTuple_Pack(1, __pyx_kp_s__11); if (unlikely(!__pyx_tuple__12)) __PYX_ERR(1, 135, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__12);
-  __Pyx_GIVEREF(__pyx_tuple__12);
+  __pyx_tuple__13 = PyTuple_Pack(1, __pyx_kp_s__12); if (unlikely(!__pyx_tuple__13)) __PYX_ERR(1, 147, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__13);
+  __Pyx_GIVEREF(__pyx_tuple__13);
 
-  /* "url/url.pyx":131
+  /* "url/url.pyx":143
  *     def filter_params(self, function):
- *         '''Remove parameters if function(name, value)'''
+ *         '''Remove parameters if function(name, value), name and value are bytes.'''
  *         def keep(query):             # <<<<<<<<<<<<<<
  *             name, _, value = query.partition('=')
  *             return not function(name, value)
  */
-  __pyx_tuple__14 = PyTuple_Pack(4, __pyx_n_s_query, __pyx_n_s_name_2, __pyx_n_s__13, __pyx_n_s_value); if (unlikely(!__pyx_tuple__14)) __PYX_ERR(1, 131, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__14);
-  __Pyx_GIVEREF(__pyx_tuple__14);
-  __pyx_codeobj__15 = (PyObject*)__Pyx_PyCode_New(1, 0, 4, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__14, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_vagrant_url_url_pyx, __pyx_n_s_keep, 131, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__15)) __PYX_ERR(1, 131, __pyx_L1_error)
+  __pyx_tuple__15 = PyTuple_Pack(4, __pyx_n_s_query, __pyx_n_s_name_2, __pyx_n_s__14, __pyx_n_s_value); if (unlikely(!__pyx_tuple__15)) __PYX_ERR(1, 143, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__15);
+  __Pyx_GIVEREF(__pyx_tuple__15);
+  __pyx_codeobj__16 = (PyObject*)__Pyx_PyCode_New(1, 0, 4, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__15, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_vagrant_url_url_pyx, __pyx_n_s_keep, 143, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__16)) __PYX_ERR(1, 143, __pyx_L1_error)
 
-  /* "url/url.pyx":160
+  /* "url/url.pyx":172
  *             self.ptr.relative_to(<string>base)
  *         elif isinstance(base, unicode):
  *             self.ptr.relative_to(<string>(base.encode('utf-8')))             # <<<<<<<<<<<<<<
  *         else:
- *             self.ptr.relative_to(<const Url&>dereference((<URL?>base).ptr))
+ *             self.ptr.relative_to(<const Url&>dereference((<StringURL?>base).ptr))
  */
-  __pyx_tuple__16 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__16)) __PYX_ERR(1, 160, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__16);
-  __Pyx_GIVEREF(__pyx_tuple__16);
+  __pyx_tuple__17 = PyTuple_Pack(1, __pyx_kp_s_utf_8); if (unlikely(!__pyx_tuple__17)) __PYX_ERR(1, 172, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__17);
+  __Pyx_GIVEREF(__pyx_tuple__17);
 
-  /* "url/url.pyx":7
+  /* "url/url.pyx":9
  * import pkgutil
  * 
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))             # <<<<<<<<<<<<<<
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):
  */
-  __pyx_tuple__17 = PyTuple_Pack(2, __pyx_n_s_url, __pyx_kp_s_psl_2016_08_16_psl); if (unlikely(!__pyx_tuple__17)) __PYX_ERR(1, 7, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__17);
-  __Pyx_GIVEREF(__pyx_tuple__17);
+  __pyx_tuple__18 = PyTuple_Pack(2, __pyx_n_s_url, __pyx_kp_s_psl_2016_08_16_psl); if (unlikely(!__pyx_tuple__18)) __PYX_ERR(1, 9, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__18);
+  __Pyx_GIVEREF(__pyx_tuple__18);
 
-  /* "url/url.pyx":9
+  /* "url/url.pyx":11
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):             # <<<<<<<<<<<<<<
  *     if isinstance(s, bytes):
  *         if encoding == 'utf-8':
  */
-  __pyx_tuple__18 = PyTuple_Pack(3, __pyx_n_s_cls, __pyx_n_s_s, __pyx_n_s_encoding); if (unlikely(!__pyx_tuple__18)) __PYX_ERR(1, 9, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__18);
-  __Pyx_GIVEREF(__pyx_tuple__18);
-  __pyx_codeobj_ = (PyObject*)__Pyx_PyCode_New(3, 0, 3, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__18, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_vagrant_url_url_pyx, __pyx_n_s_ParseMethod, 9, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj_)) __PYX_ERR(1, 9, __pyx_L1_error)
+  __pyx_tuple__19 = PyTuple_Pack(3, __pyx_n_s_cls, __pyx_n_s_s, __pyx_n_s_encoding); if (unlikely(!__pyx_tuple__19)) __PYX_ERR(1, 11, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__19);
+  __Pyx_GIVEREF(__pyx_tuple__19);
+  __pyx_codeobj_ = (PyObject*)__Pyx_PyCode_New(3, 0, 3, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__19, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_vagrant_url_url_pyx, __pyx_n_s_ParseMethod, 11, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj_)) __PYX_ERR(1, 11, __pyx_L1_error)
 
-  /* "url/url.pyx":18
+  /* "url/url.pyx":20
  *         return cls(s.encode('utf-8'))
  * 
  * def set_psl(rules):             # <<<<<<<<<<<<<<
  *     global psl
- *     psl = PSL.fromString(rules)
+ *     psl = PSL.fromString(as_bytes(rules))
  */
-  __pyx_tuple__19 = PyTuple_Pack(1, __pyx_n_s_rules); if (unlikely(!__pyx_tuple__19)) __PYX_ERR(1, 18, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_tuple__19);
-  __Pyx_GIVEREF(__pyx_tuple__19);
-  __pyx_codeobj__4 = (PyObject*)__Pyx_PyCode_New(1, 0, 1, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__19, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_vagrant_url_url_pyx, __pyx_n_s_set_psl, 18, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__4)) __PYX_ERR(1, 18, __pyx_L1_error)
+  __pyx_tuple__20 = PyTuple_Pack(1, __pyx_n_s_rules); if (unlikely(!__pyx_tuple__20)) __PYX_ERR(1, 20, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_tuple__20);
+  __Pyx_GIVEREF(__pyx_tuple__20);
+  __pyx_codeobj__4 = (PyObject*)__Pyx_PyCode_New(1, 0, 1, 0, 0, __pyx_empty_bytes, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_tuple__20, __pyx_empty_tuple, __pyx_empty_tuple, __pyx_kp_s_vagrant_url_url_pyx, __pyx_n_s_set_psl, 20, __pyx_empty_bytes); if (unlikely(!__pyx_codeobj__4)) __PYX_ERR(1, 20, __pyx_L1_error)
   __Pyx_RefNannyFinishContext();
   return 0;
   __pyx_L1_error:;
@@ -8110,23 +9949,28 @@ PyMODINIT_FUNC PyInit_url(void)
   /*--- Variable export code ---*/
   /*--- Function export code ---*/
   /*--- Type init code ---*/
-  if (PyType_Ready(&__pyx_type_3url_3url_URL) < 0) __PYX_ERR(1, 23, __pyx_L1_error)
-  __pyx_type_3url_3url_URL.tp_print = 0;
-  if (PyObject_SetAttrString(__pyx_m, "URL", (PyObject *)&__pyx_type_3url_3url_URL) < 0) __PYX_ERR(1, 23, __pyx_L1_error)
-  __pyx_ptype_3url_3url_URL = &__pyx_type_3url_3url_URL;
-  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct__deparam) < 0) __PYX_ERR(1, 123, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_3url_3url_StringURL) < 0) __PYX_ERR(1, 29, __pyx_L1_error)
+  __pyx_type_3url_3url_StringURL.tp_print = 0;
+  if (PyObject_SetAttrString(__pyx_m, "StringURL", (PyObject *)&__pyx_type_3url_3url_StringURL) < 0) __PYX_ERR(1, 29, __pyx_L1_error)
+  __pyx_ptype_3url_3url_StringURL = &__pyx_type_3url_3url_StringURL;
+  __pyx_type_3url_3url_UnicodeURL.tp_base = __pyx_ptype_3url_3url_StringURL;
+  if (PyType_Ready(&__pyx_type_3url_3url_UnicodeURL) < 0) __PYX_ERR(1, 255, __pyx_L1_error)
+  __pyx_type_3url_3url_UnicodeURL.tp_print = 0;
+  if (PyObject_SetAttrString(__pyx_m, "UnicodeURL", (PyObject *)&__pyx_type_3url_3url_UnicodeURL) < 0) __PYX_ERR(1, 255, __pyx_L1_error)
+  __pyx_ptype_3url_3url_UnicodeURL = &__pyx_type_3url_3url_UnicodeURL;
+  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct__deparam) < 0) __PYX_ERR(1, 135, __pyx_L1_error)
   __pyx_type_3url_3url___pyx_scope_struct__deparam.tp_print = 0;
   __pyx_ptype_3url_3url___pyx_scope_struct__deparam = &__pyx_type_3url_3url___pyx_scope_struct__deparam;
-  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_1_genexpr) < 0) __PYX_ERR(1, 125, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_1_genexpr) < 0) __PYX_ERR(1, 137, __pyx_L1_error)
   __pyx_type_3url_3url___pyx_scope_struct_1_genexpr.tp_print = 0;
   __pyx_ptype_3url_3url___pyx_scope_struct_1_genexpr = &__pyx_type_3url_3url___pyx_scope_struct_1_genexpr;
-  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_2_filter_params) < 0) __PYX_ERR(1, 129, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_2_filter_params) < 0) __PYX_ERR(1, 141, __pyx_L1_error)
   __pyx_type_3url_3url___pyx_scope_struct_2_filter_params.tp_print = 0;
   __pyx_ptype_3url_3url___pyx_scope_struct_2_filter_params = &__pyx_type_3url_3url___pyx_scope_struct_2_filter_params;
-  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_3_genexpr) < 0) __PYX_ERR(1, 134, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_3_genexpr) < 0) __PYX_ERR(1, 146, __pyx_L1_error)
   __pyx_type_3url_3url___pyx_scope_struct_3_genexpr.tp_print = 0;
   __pyx_ptype_3url_3url___pyx_scope_struct_3_genexpr = &__pyx_type_3url_3url___pyx_scope_struct_3_genexpr;
-  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_4_genexpr) < 0) __PYX_ERR(1, 135, __pyx_L1_error)
+  if (PyType_Ready(&__pyx_type_3url_3url___pyx_scope_struct_4_genexpr) < 0) __PYX_ERR(1, 147, __pyx_L1_error)
   __pyx_type_3url_3url___pyx_scope_struct_4_genexpr.tp_print = 0;
   __pyx_ptype_3url_3url___pyx_scope_struct_4_genexpr = &__pyx_type_3url_3url___pyx_scope_struct_4_genexpr;
   /*--- Type import code ---*/
@@ -8138,81 +9982,103 @@ PyMODINIT_FUNC PyInit_url(void)
   #endif
   __Pyx_TraceCall("PyMODINIT_FUNC PyInit_url(void)", __pyx_f[1], 1, 0, __PYX_ERR(1, 1, __pyx_L1_error));
 
-  /* "url/url.pyx":5
+  /* "url/url.pyx":4
+ * # distutils: define_macros=CYTHON_TRACE=1
+ * 
+ * from six import text_type             # <<<<<<<<<<<<<<
+ * 
+ * from cython.operator import dereference
+ */
+  __Pyx_TraceLine(4,0,__PYX_ERR(1, 4, __pyx_L1_error))
+  __pyx_t_1 = PyList_New(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 4, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __Pyx_INCREF(__pyx_n_s_text_type);
+  __Pyx_GIVEREF(__pyx_n_s_text_type);
+  PyList_SET_ITEM(__pyx_t_1, 0, __pyx_n_s_text_type);
+  __pyx_t_2 = __Pyx_Import(__pyx_n_s_six, __pyx_t_1, -1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 4, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_t_1 = __Pyx_ImportFrom(__pyx_t_2, __pyx_n_s_text_type); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 4, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_text_type, __pyx_t_1) < 0) __PYX_ERR(1, 4, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+
+  /* "url/url.pyx":7
  * 
  * from cython.operator import dereference
  * import pkgutil             # <<<<<<<<<<<<<<
  * 
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))
  */
-  __Pyx_TraceLine(5,0,__PYX_ERR(1, 5, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_Import(__pyx_n_s_pkgutil, 0, -1); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 5, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_pkgutil, __pyx_t_1) < 0) __PYX_ERR(1, 5, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_TraceLine(7,0,__PYX_ERR(1, 7, __pyx_L1_error))
+  __pyx_t_2 = __Pyx_Import(__pyx_n_s_pkgutil, 0, -1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 7, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_pkgutil, __pyx_t_2) < 0) __PYX_ERR(1, 7, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "url/url.pyx":7
+  /* "url/url.pyx":9
  * import pkgutil
  * 
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))             # <<<<<<<<<<<<<<
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):
  */
-  __Pyx_TraceLine(7,0,__PYX_ERR(1, 7, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_pkgutil); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 7, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_get_data); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 7, __pyx_L1_error)
+  __Pyx_TraceLine(9,0,__PYX_ERR(1, 9, __pyx_L1_error))
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_pkgutil); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 9, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_tuple__17, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 7, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_get_data); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 9, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_3 = __pyx_convert_string_from_py_std__in_string(__pyx_t_1); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 7, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_tuple__18, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 9, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __pyx_t_3 = __pyx_convert_string_from_py_std__in_string(__pyx_t_2); if (unlikely(PyErr_Occurred())) __PYX_ERR(1, 9, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_3url_3url_psl = Url::PSL::fromString(__pyx_t_3);
 
-  /* "url/url.pyx":9
+  /* "url/url.pyx":11
  * cdef PSL psl = PSL.fromString(pkgutil.get_data('url', 'psl/2016-08-16.psl'))
  * 
  * def ParseMethod(cls, s, encoding='utf-8'):             # <<<<<<<<<<<<<<
  *     if isinstance(s, bytes):
  *         if encoding == 'utf-8':
  */
-  __Pyx_TraceLine(9,0,__PYX_ERR(1, 9, __pyx_L1_error))
-  __pyx_t_1 = PyCFunction_NewEx(&__pyx_mdef_3url_3url_1ParseMethod, NULL, __pyx_n_s_url_url); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 9, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_ParseMethod, __pyx_t_1) < 0) __PYX_ERR(1, 9, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_TraceLine(11,0,__PYX_ERR(1, 11, __pyx_L1_error))
+  __pyx_t_2 = PyCFunction_NewEx(&__pyx_mdef_3url_3url_1ParseMethod, NULL, __pyx_n_s_url_url); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 11, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_ParseMethod, __pyx_t_2) < 0) __PYX_ERR(1, 11, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "url/url.pyx":18
+  /* "url/url.pyx":20
  *         return cls(s.encode('utf-8'))
  * 
  * def set_psl(rules):             # <<<<<<<<<<<<<<
  *     global psl
- *     psl = PSL.fromString(rules)
+ *     psl = PSL.fromString(as_bytes(rules))
  */
-  __Pyx_TraceLine(18,0,__PYX_ERR(1, 18, __pyx_L1_error))
-  __pyx_t_1 = PyCFunction_NewEx(&__pyx_mdef_3url_3url_3set_psl, NULL, __pyx_n_s_url_url); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 18, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_set_psl, __pyx_t_1) < 0) __PYX_ERR(1, 18, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  __Pyx_TraceLine(20,0,__PYX_ERR(1, 20, __pyx_L1_error))
+  __pyx_t_2 = PyCFunction_NewEx(&__pyx_mdef_3url_3url_3set_psl, NULL, __pyx_n_s_url_url); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 20, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_2);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_set_psl, __pyx_t_2) < 0) __PYX_ERR(1, 20, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-  /* "url/url.pyx":28
+  /* "url/url.pyx":34
  *     cdef Url *ptr
  * 
  *     parse = classmethod(ParseMethod)             # <<<<<<<<<<<<<<
  * 
  *     def __cinit__(self, const string& s):
  */
-  __Pyx_TraceLine(28,0,__PYX_ERR(1, 28, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_GetModuleGlobalName(__pyx_n_s_ParseMethod); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 28, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_Method_ClassMethod(__pyx_t_1); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 28, __pyx_L1_error)
+  __Pyx_TraceLine(34,0,__PYX_ERR(1, 34, __pyx_L1_error))
+  __pyx_t_2 = __Pyx_GetModuleGlobalName(__pyx_n_s_ParseMethod); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 34, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (PyDict_SetItem((PyObject *)__pyx_ptype_3url_3url_URL->tp_dict, __pyx_n_s_parse, __pyx_t_2) < 0) __PYX_ERR(1, 28, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_Method_ClassMethod(__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 34, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  PyType_Modified(__pyx_ptype_3url_3url_URL);
+  if (PyDict_SetItem((PyObject *)__pyx_ptype_3url_3url_StringURL->tp_dict, __pyx_n_s_parse, __pyx_t_1) < 0) __PYX_ERR(1, 34, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+  PyType_Modified(__pyx_ptype_3url_3url_StringURL);
 
   /* "url/url.pyx":1
  * # cython: linetrace=True             # <<<<<<<<<<<<<<
@@ -8220,10 +10086,10 @@ PyMODINIT_FUNC PyInit_url(void)
  * 
  */
   __Pyx_TraceLine(1,0,__PYX_ERR(1, 1, __pyx_L1_error))
-  __pyx_t_2 = PyDict_New(); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 1, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_2);
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_test, __pyx_t_2) < 0) __PYX_ERR(1, 1, __pyx_L1_error)
-  __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+  __pyx_t_1 = PyDict_New(); if (unlikely(!__pyx_t_1)) __PYX_ERR(1, 1, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_test, __pyx_t_1) < 0) __PYX_ERR(1, 1, __pyx_L1_error)
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
   /* "set.to_py":144
  * 
@@ -8721,8 +10587,26 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallOneArg(PyObject *func, PyObjec
 }
 #endif
 
+/* GetModuleGlobalName */
+  static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name) {
+    PyObject *result;
+#if CYTHON_COMPILING_IN_CPYTHON
+    result = PyDict_GetItem(__pyx_d, name);
+    if (likely(result)) {
+        Py_INCREF(result);
+    } else {
+#else
+    result = PyObject_GetItem(__pyx_d, name);
+    if (!result) {
+        PyErr_Clear();
+#endif
+        result = __Pyx_GetBuiltinName(name);
+    }
+    return result;
+}
+
 /* PyErrFetchRestore */
-  #if CYTHON_COMPILING_IN_CPYTHON
+    #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE void __Pyx_ErrRestoreInState(PyThreadState *tstate, PyObject *type, PyObject *value, PyObject *tb) {
     PyObject *tmp_type, *tmp_value, *tmp_tb;
     tmp_type = tstate->curexc_type;
@@ -8746,7 +10630,7 @@ static CYTHON_INLINE void __Pyx_ErrFetchInState(PyThreadState *tstate, PyObject 
 #endif
 
 /* WriteUnraisableException */
-  static void __Pyx_WriteUnraisable(const char *name, CYTHON_UNUSED int clineno,
+    static void __Pyx_WriteUnraisable(const char *name, CYTHON_UNUSED int clineno,
                                   CYTHON_UNUSED int lineno, CYTHON_UNUSED const char *filename,
                                   int full_traceback, CYTHON_UNUSED int nogil) {
     PyObject *old_exc, *old_val, *old_tb;
@@ -8788,7 +10672,7 @@ static CYTHON_INLINE void __Pyx_ErrFetchInState(PyThreadState *tstate, PyObject 
 }
 
 /* ExtTypeTest */
-  static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type) {
+    static CYTHON_INLINE int __Pyx_TypeTest(PyObject *obj, PyTypeObject *type) {
     if (unlikely(!type)) {
         PyErr_SetString(PyExc_SystemError, "Missing type object");
         return 0;
@@ -8801,7 +10685,7 @@ static CYTHON_INLINE void __Pyx_ErrFetchInState(PyThreadState *tstate, PyObject 
 }
 
 /* PyIntBinop */
-  #if CYTHON_COMPILING_IN_CPYTHON
+    #if CYTHON_COMPILING_IN_CPYTHON
 static PyObject* __Pyx_PyInt_EqObjC(PyObject *op1, PyObject *op2, CYTHON_UNUSED long intval, CYTHON_UNUSED int inplace) {
     if (op1 == op2) {
         Py_RETURN_TRUE;
@@ -8886,7 +10770,7 @@ static PyObject* __Pyx_PyInt_EqObjC(PyObject *op1, PyObject *op2, CYTHON_UNUSED 
 #endif
 
 /* RaiseException */
-  #if PY_MAJOR_VERSION < 3
+    #if PY_MAJOR_VERSION < 3
 static void __Pyx_Raise(PyObject *type, PyObject *value, PyObject *tb,
                         CYTHON_UNUSED PyObject *cause) {
     __Pyx_PyThreadState_declare
@@ -9049,12 +10933,12 @@ bad:
 #endif
 
 /* None */
-    static CYTHON_INLINE void __Pyx_RaiseClosureNameError(const char *varname) {
+      static CYTHON_INLINE void __Pyx_RaiseClosureNameError(const char *varname) {
     PyErr_Format(PyExc_NameError, "free variable '%s' referenced before assignment in enclosing scope", varname);
 }
 
 /* PyObjectCallNoArg */
-    #if CYTHON_COMPILING_IN_CPYTHON
+      #if CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
 #ifdef __Pyx_CyFunction_USED
     if (likely(PyCFunction_Check(func) || PyObject_TypeCheck(func, __pyx_CyFunctionType))) {
@@ -9070,20 +10954,20 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
 #endif
 
 /* RaiseTooManyValuesToUnpack */
-      static CYTHON_INLINE void __Pyx_RaiseTooManyValuesError(Py_ssize_t expected) {
+        static CYTHON_INLINE void __Pyx_RaiseTooManyValuesError(Py_ssize_t expected) {
     PyErr_Format(PyExc_ValueError,
                  "too many values to unpack (expected %" CYTHON_FORMAT_SSIZE_T "d)", expected);
 }
 
 /* RaiseNeedMoreValuesToUnpack */
-      static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index) {
+        static CYTHON_INLINE void __Pyx_RaiseNeedMoreValuesError(Py_ssize_t index) {
     PyErr_Format(PyExc_ValueError,
                  "need more than %" CYTHON_FORMAT_SSIZE_T "d value%.1s to unpack",
                  index, (index == 1) ? "" : "s");
 }
 
 /* IterFinish */
-      static CYTHON_INLINE int __Pyx_IterFinish(void) {
+        static CYTHON_INLINE int __Pyx_IterFinish(void) {
 #if CYTHON_COMPILING_IN_CPYTHON
     PyThreadState *tstate = PyThreadState_GET();
     PyObject* exc_type = tstate->curexc_type;
@@ -9118,7 +11002,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
 }
 
 /* UnpackItemEndCheck */
-      static int __Pyx_IternextUnpackEndCheck(PyObject *retval, Py_ssize_t expected) {
+        static int __Pyx_IternextUnpackEndCheck(PyObject *retval, Py_ssize_t expected) {
     if (unlikely(retval)) {
         Py_DECREF(retval);
         __Pyx_RaiseTooManyValuesError(expected);
@@ -9130,7 +11014,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyObject_CallNoArg(PyObject *func) {
 }
 
 /* FetchCommonType */
-      static PyTypeObject* __Pyx_FetchCommonType(PyTypeObject* type) {
+        static PyTypeObject* __Pyx_FetchCommonType(PyTypeObject* type) {
     PyObject* fake_module;
     PyTypeObject* cached_type = NULL;
     fake_module = PyImport_AddModule((char*) "_cython_" CYTHON_ABI);
@@ -9169,7 +11053,7 @@ bad:
 }
 
 /* CythonFunction */
-      static PyObject *
+        static PyObject *
 __Pyx_CyFunction_get_doc(__pyx_CyFunctionObject *op, CYTHON_UNUSED void *closure)
 {
     if (unlikely(op->func_doc == NULL)) {
@@ -9736,14 +11620,14 @@ static CYTHON_INLINE void __Pyx_CyFunction_SetAnnotationsDict(PyObject *func, Py
 }
 
 /* StringJoin */
-          #if !CYTHON_COMPILING_IN_CPYTHON
+            #if !CYTHON_COMPILING_IN_CPYTHON
 static CYTHON_INLINE PyObject* __Pyx_PyBytes_Join(PyObject* sep, PyObject* values) {
     return PyObject_CallMethodObjArgs(sep, __pyx_n_s_join, values, NULL);
 }
 #endif
 
 /* decode_c_bytes */
-          static CYTHON_INLINE PyObject* __Pyx_decode_c_bytes(
+            static CYTHON_INLINE PyObject* __Pyx_decode_c_bytes(
          const char* cstring, Py_ssize_t length, Py_ssize_t start, Py_ssize_t stop,
          const char* encoding, const char* errors,
          PyObject* (*decode_func)(const char *s, Py_ssize_t size, const char *errors)) {
@@ -9770,7 +11654,7 @@ static CYTHON_INLINE PyObject* __Pyx_PyBytes_Join(PyObject* sep, PyObject* value
 }
 
 /* Import */
-          static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level) {
+            static PyObject *__Pyx_Import(PyObject *name, PyObject *from_list, int level) {
     PyObject *empty_list = 0;
     PyObject *module = 0;
     PyObject *global_dict = 0;
@@ -9843,22 +11727,18 @@ bad:
     return module;
 }
 
-/* GetModuleGlobalName */
-          static CYTHON_INLINE PyObject *__Pyx_GetModuleGlobalName(PyObject *name) {
-    PyObject *result;
-#if CYTHON_COMPILING_IN_CPYTHON
-    result = PyDict_GetItem(__pyx_d, name);
-    if (likely(result)) {
-        Py_INCREF(result);
-    } else {
-#else
-    result = PyObject_GetItem(__pyx_d, name);
-    if (!result) {
-        PyErr_Clear();
-#endif
-        result = __Pyx_GetBuiltinName(name);
+/* ImportFrom */
+            static PyObject* __Pyx_ImportFrom(PyObject* module, PyObject* name) {
+    PyObject* value = __Pyx_PyObject_GetAttrStr(module, name);
+    if (unlikely(!value) && PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        PyErr_Format(PyExc_ImportError,
+        #if PY_MAJOR_VERSION < 3
+            "cannot import name %.230s", PyString_AS_STRING(name));
+        #else
+            "cannot import name %S", name);
+        #endif
     }
-    return result;
+    return value;
 }
 
 /* CodeObjectCache */

--- a/url/url.pyx
+++ b/url/url.pyx
@@ -1,6 +1,8 @@
 # cython: linetrace=True
 # distutils: define_macros=CYTHON_TRACE=1
 
+from six import text_type
+
 from cython.operator import dereference
 import pkgutil
 
@@ -17,11 +19,15 @@ def ParseMethod(cls, s, encoding='utf-8'):
 
 def set_psl(rules):
     global psl
-    psl = PSL.fromString(rules)
+    psl = PSL.fromString(as_bytes(rules))
 
+cdef as_bytes(obj):
+    if isinstance(obj, text_type):
+        return obj.encode('utf-8')
+    return obj
 
-cdef class URL:
-    '''Wrapper around url-cpp.'''
+cdef class StringURL:
+    '''Wrapper around url-cpp, which deals in strings.'''
 
     cdef Url *ptr
 
@@ -37,13 +43,13 @@ cdef class URL:
         def __get__(self):
             return self.ptr.scheme()
         def __set__(self, s):
-            self.ptr.setScheme(s)
+            self.ptr.setScheme(as_bytes(s))
 
     property host:
         def __get__(self):
             return self.ptr.host()
         def __set__(self, s):
-            self.ptr.setHost(s)
+            self.ptr.setHost(as_bytes(s))
 
     property port:
         def __get__(self):
@@ -55,35 +61,35 @@ cdef class URL:
         def __get__(self):
             return self.ptr.path()
         def __set__(self, s):
-            self.ptr.setPath(s)
+            self.ptr.setPath(as_bytes(s))
 
     property params:
         def __get__(self):
             return self.ptr.params()
         def __set__(self, s):
-            self.ptr.setParams(s)
+            self.ptr.setParams(as_bytes(s))
 
     property query:
         def __get__(self):
             return self.ptr.query()
         def __set__(self, s):
-            self.ptr.setQuery(s)
+            self.ptr.setQuery(as_bytes(s))
 
     property fragment:
         def __get__(self):
             return self.ptr.fragment()
         def __set__(self, s):
-            self.ptr.setFragment(s)
+            self.ptr.setFragment(as_bytes(s))
 
     property userinfo:
         def __get__(self):
             return self.ptr.userinfo()
         def __set__(self, s):
-            self.ptr.setUserinfo(s)
+            self.ptr.setUserinfo(as_bytes(s))
 
     def copy(self):
         '''Return a new instance of an identical URL.'''
-        new = URL('')
+        new = StringURL(b'')
         new.ptr.assign(dereference(self.ptr));
         return new
 
@@ -91,25 +97,31 @@ cdef class URL:
         '''Return true if this url is equivalent to another'''
         if isinstance(other, basestring):
             return self.equiv(self.parse(other, encoding))
-        return self.ptr.equiv(dereference((<URL?>other).ptr))
+        return self.ptr.equiv(dereference((<StringURL?>other).ptr))
 
     def __richcmp__(self, other, op):
         '''Return true if this url is /exactly/ equal to another'''
         if op == 2:  # ==
             if isinstance(other, basestring):
                 return self.__eq__(self.parse(other, 'utf-8'))
-            return dereference((<URL>self).ptr) == dereference((<URL?>other).ptr)
+            return dereference((<StringURL>self).ptr) == dereference((<StringURL?>other).ptr)
         elif op == 3:  # !=
             return not (self == other)
         else:
             raise NotImplementedError(
                 '%s does not support this operation.' % type(self).__name__)
 
+    def __unicode__(self):
+        return self.unicode
+
     def __str__(self):
         return self.utf8
 
+    def __bytes__(self):
+        return self.utf8
+
     def __repr__(self):
-        return '<url.URL object "%s" >' % self.utf8
+        return '<url.URL object "%s" >' % str(self)
 
     def canonical(self):
         self.ptr.sort_query()
@@ -122,12 +134,12 @@ cdef class URL:
 
     def deparam(self, params):
         '''Strip any of the provided parameters out of the url'''
-        lowered = unordered_set[string](p.lower() for p in params)
+        lowered = unordered_set[string](as_bytes(p.lower()) for p in params)
         self.ptr.deparam(lowered)
         return self
 
     def filter_params(self, function):
-        '''Remove parameters if function(name, value)'''
+        '''Remove parameters if function(name, value), name and value are bytes.'''
         def keep(query):
             name, _, value = query.partition('=')
             return not function(name, value)
@@ -159,7 +171,7 @@ cdef class URL:
         elif isinstance(base, unicode):
             self.ptr.relative_to(<string>(base.encode('utf-8')))
         else:
-            self.ptr.relative_to(<const Url&>dereference((<URL?>base).ptr))
+            self.ptr.relative_to(<const Url&>dereference((<StringURL?>base).ptr))
         self.ptr.abspath()
         return self
 
@@ -205,7 +217,7 @@ cdef class URL:
     ###########################################################################
     property hostname:
         def __get__(self):
-            return self.ptr.host()
+            return self.host
 
     property pld:
         '''Return the 'pay-level domain' of the url
@@ -213,14 +225,14 @@ cdef class URL:
         def __get__(self):
             if not self.ptr.host().empty():
                 return psl.getPLD(self.ptr.host())
-            return ''
+            return b''
 
     property tld:
         '''Return the top-level domain of a url'''
         def __get__(self):
             if not self.ptr.host().empty():
                 return psl.getTLD(self.ptr.host())
-            return ''
+            return b''
 
     property absolute:
         '''Return True if this is a fully-qualified URL with a hostname and everything'''
@@ -238,3 +250,66 @@ cdef class URL:
         '''Return a utf-8 version of this url'''
         def __get__(self):
             return self.ptr.str()
+
+
+cdef class UnicodeURL(StringURL):
+    '''A version of the URL class that deals in Unicode.'''
+    property scheme:
+        def __get__(self):
+            return text_type(self.ptr.scheme(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setScheme(as_bytes(s))
+
+    property host:
+        def __get__(self):
+            return text_type(self.ptr.host(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setHost(as_bytes(s))
+
+    property path:
+        def __get__(self):
+            return text_type(self.ptr.path(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setPath(as_bytes(s))
+
+    property params:
+        def __get__(self):
+            return text_type(self.ptr.params(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setParams(as_bytes(s))
+
+    property query:
+        def __get__(self):
+            return text_type(self.ptr.query(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setQuery(as_bytes(s))
+
+    property fragment:
+        def __get__(self):
+            return text_type(self.ptr.fragment(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setFragment(as_bytes(s))
+
+    property userinfo:
+        def __get__(self):
+            return text_type(self.ptr.userinfo(), encoding='utf-8')
+        def __set__(self, s):
+            self.ptr.setUserinfo(as_bytes(s))
+
+    property pld:
+        '''Return the 'pay-level domain' of the url
+            (http://moz.com/blog/what-the-heck-should-we-call-domaincom)'''
+        def __get__(self):
+            if not self.ptr.host().empty():
+                return psl.getPLD(self.ptr.host()).decode('utf-8')
+            return u''
+
+    property tld:
+        '''Return the top-level domain of a url'''
+        def __get__(self):
+            if not self.ptr.host().empty():
+                return psl.getTLD(self.ptr.host()).decode('utf-8')
+            return u''
+
+    def __str__(self):
+        return self.unicode


### PR DESCRIPTION
This is because `reppy` would like to potentially use `url-py`, and `reppy` has thus far maintained support for python 3.

@b4hand @lindseyreno @neilmb 