### PR TITLE
Add python 3 classifiers and 3.6 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
 # before_install: scripts/travis/before_install.sh
 install: pip install -r requirements.txt
 script: make test

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,13 @@ cleaning parameter and query strings, and a little more sanitization.
         'Development Status :: 3 - Alpha',
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
-        'Topic :: Internet :: WWW/HTTP'
+        'Topic :: Internet :: WWW/HTTP',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     ext_modules      = ext_modules,
     packages         = [


### PR DESCRIPTION
While the codebase has been tested on travis with python 3 for some time, adding the language classifiers helps tools such as [caniusepython3](https://github.com/brettcannon/caniusepython3) know if the package works under python 3.

This change also adds python 3.6 to travis as it's the most recent version of python.