### PR TITLE
Bump version to 0.4.1 for updated package metadata.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ ext_modules = [
 
 setup(
     name='url',
-    version='0.4.0',
+    version='0.4.1',
     description='URL Parsing',
     long_description='''
 Some helper functions for parsing URLs, sanitizing them, normalizing them.


### PR DESCRIPTION
The package metadata was updated in #51, but we've not created a new release since that point in time. After merging this PR, I'll tag and publish a new version on pypi, so that it will have the updated package metadata.