### PR TITLE
Catch C++ exceptions for empty segments

### DIFF
--- a/test.py
+++ b/test.py
@@ -591,6 +591,12 @@ def test_pld():
         yield test, query, result
 
 
+def test_pld_raises():
+    def get_pld(query):
+        return url.parse(query).pld
+    assert_raises(ValueError, get_pld, 'http://site..com')
+
+
 def test_tld():
     def test(query, result):
         assert_equal(url.parse(query).tld, result)

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -6411,7 +6411,8 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3ur
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
-  PyObject *__pyx_t_2 = NULL;
+  std::string __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_TraceCall("__get__", __pyx_f[1], 233, 0, __PYX_ERR(1, 233, __pyx_L1_error));
 
@@ -6435,10 +6436,16 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3ur
  */
     __Pyx_TraceLine(235,0,__PYX_ERR(1, 235, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 235, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_r = __pyx_t_2;
-    __pyx_t_2 = 0;
+    try {
+      __pyx_t_2 = __pyx_v_3url_3url_psl.getPLD(__pyx_v_self->ptr->host());
+    } catch(...) {
+      __Pyx_CppExn2PyErr();
+      __PYX_ERR(1, 235, __pyx_L1_error)
+    }
+    __pyx_t_3 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 235, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_r = __pyx_t_3;
+    __pyx_t_3 = 0;
     goto __pyx_L0;
 
     /* "url/url.pyx":234
@@ -6473,7 +6480,7 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3ur
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
   __Pyx_AddTraceback("url.url.StringURL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -7879,7 +7886,8 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
-  PyObject *__pyx_t_2 = NULL;
+  std::string __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_TraceCall("__get__", __pyx_f[1], 310, 0, __PYX_ERR(1, 310, __pyx_L1_error));
 
@@ -7903,10 +7911,16 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3
  */
     __Pyx_TraceLine(312,0,__PYX_ERR(1, 312, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __Pyx_decode_cpp_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->__pyx_base.ptr->host()), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 312, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_r = __pyx_t_2;
-    __pyx_t_2 = 0;
+    try {
+      __pyx_t_2 = __pyx_v_3url_3url_psl.getPLD(__pyx_v_self->__pyx_base.ptr->host());
+    } catch(...) {
+      __Pyx_CppExn2PyErr();
+      __PYX_ERR(1, 312, __pyx_L1_error)
+    }
+    __pyx_t_3 = __Pyx_decode_cpp_string(__pyx_t_2, 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 312, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_r = __pyx_t_3;
+    __pyx_t_3 = 0;
     goto __pyx_L0;
 
     /* "url/url.pyx":311
@@ -7941,7 +7955,7 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
   __Pyx_AddTraceback("url.url.UnicodeURL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;

--- a/url/url.pxd
+++ b/url/url.pxd
@@ -14,7 +14,7 @@ cdef extern from "url-cpp/include/psl.h" namespace "Url":
         @staticmethod
         PSL fromString(const string& str)
         string getTLD(const string& hostname) const
-        string getPLD(const string& hostname) const
+        string getPLD(const string& hostname) except +
 
 
 cdef extern from "url-cpp/include/url.h" namespace "Url":


### PR DESCRIPTION
This fixes issue #56 by annotating the `PSL.getPLD` method as possibly raising an exception.

https://stackoverflow.com/questions/26904268/cython-both-const-and-except-in-c-method-declaration references the fact that the `const` and `except +` qualifiers cannot co-exist, but also that the trailing `const` qualifier is unnecessary.