### PR TITLE
Fix exception handling for getPLD/getTLD.

### DIFF
--- a/test.py
+++ b/test.py
@@ -4,7 +4,9 @@
 import pkgutil
 
 import six
-from nose.tools import assert_equal, assert_not_equal, assert_raises, assert_is_instance
+from nose.tools import (
+    assert_equal, assert_not_equal, assert_raises, assert_is_instance,
+    raises)
 
 import url
 from url.url import StringURL, UnicodeURL
@@ -663,6 +665,11 @@ def test_set_psl():
 
     for rules, example, pld, tld in examples:
         yield test, rules, example, pld, tld
+
+@raises(ValueError)
+def test_psl_exception():
+    '''Raises ValueError when PSL code throws.'''
+    url.parse('http://empty..com').pld
 
 def test_tel():
     '''Can parse tel links properly.'''

--- a/url/url.cpp
+++ b/url/url.cpp
@@ -6411,7 +6411,8 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3ur
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
-  PyObject *__pyx_t_2 = NULL;
+  std::string __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_TraceCall("__get__", __pyx_f[1], 233, 0, __PYX_ERR(1, 233, __pyx_L1_error));
 
@@ -6435,10 +6436,16 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3ur
  */
     __Pyx_TraceLine(235,0,__PYX_ERR(1, 235, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 235, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_r = __pyx_t_2;
-    __pyx_t_2 = 0;
+    try {
+      __pyx_t_2 = __pyx_v_3url_3url_psl.getPLD(__pyx_v_self->ptr->host());
+    } catch(...) {
+      __Pyx_CppExn2PyErr();
+      __PYX_ERR(1, 235, __pyx_L1_error)
+    }
+    __pyx_t_3 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 235, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_r = __pyx_t_3;
+    __pyx_t_3 = 0;
     goto __pyx_L0;
 
     /* "url/url.pyx":234
@@ -6473,7 +6480,7 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3pld___get__(struct __pyx_obj_3ur
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
   __Pyx_AddTraceback("url.url.StringURL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -6509,7 +6516,8 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3tld___get__(struct __pyx_obj_3ur
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
-  PyObject *__pyx_t_2 = NULL;
+  std::string __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_TraceCall("__get__", __pyx_f[1], 240, 0, __PYX_ERR(1, 240, __pyx_L1_error));
 
@@ -6533,10 +6541,16 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3tld___get__(struct __pyx_obj_3ur
  */
     __Pyx_TraceLine(242,0,__PYX_ERR(1, 242, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_v_3url_3url_psl.getTLD(__pyx_v_self->ptr->host())); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 242, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_r = __pyx_t_2;
-    __pyx_t_2 = 0;
+    try {
+      __pyx_t_2 = __pyx_v_3url_3url_psl.getTLD(__pyx_v_self->ptr->host());
+    } catch(...) {
+      __Pyx_CppExn2PyErr();
+      __PYX_ERR(1, 242, __pyx_L1_error)
+    }
+    __pyx_t_3 = __pyx_convert_PyBytes_string_to_py_std__in_string(__pyx_t_2); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 242, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_r = __pyx_t_3;
+    __pyx_t_3 = 0;
     goto __pyx_L0;
 
     /* "url/url.pyx":241
@@ -6571,7 +6585,7 @@ static PyObject *__pyx_pf_3url_3url_9StringURL_3tld___get__(struct __pyx_obj_3ur
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
   __Pyx_AddTraceback("url.url.StringURL.tld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -7879,7 +7893,8 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
-  PyObject *__pyx_t_2 = NULL;
+  std::string __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_TraceCall("__get__", __pyx_f[1], 310, 0, __PYX_ERR(1, 310, __pyx_L1_error));
 
@@ -7903,10 +7918,16 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3
  */
     __Pyx_TraceLine(312,0,__PYX_ERR(1, 312, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __Pyx_decode_cpp_string(__pyx_v_3url_3url_psl.getPLD(__pyx_v_self->__pyx_base.ptr->host()), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 312, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_r = __pyx_t_2;
-    __pyx_t_2 = 0;
+    try {
+      __pyx_t_2 = __pyx_v_3url_3url_psl.getPLD(__pyx_v_self->__pyx_base.ptr->host());
+    } catch(...) {
+      __Pyx_CppExn2PyErr();
+      __PYX_ERR(1, 312, __pyx_L1_error)
+    }
+    __pyx_t_3 = __Pyx_decode_cpp_string(__pyx_t_2, 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 312, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_r = __pyx_t_3;
+    __pyx_t_3 = 0;
     goto __pyx_L0;
 
     /* "url/url.pyx":311
@@ -7941,7 +7962,7 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3pld___get__(struct __pyx_obj_3
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
   __Pyx_AddTraceback("url.url.UnicodeURL.pld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -7977,7 +7998,8 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3tld___get__(struct __pyx_obj_3
   __Pyx_TraceDeclarations
   __Pyx_RefNannyDeclarations
   int __pyx_t_1;
-  PyObject *__pyx_t_2 = NULL;
+  std::string __pyx_t_2;
+  PyObject *__pyx_t_3 = NULL;
   __Pyx_RefNannySetupContext("__get__", 0);
   __Pyx_TraceCall("__get__", __pyx_f[1], 317, 0, __PYX_ERR(1, 317, __pyx_L1_error));
 
@@ -8001,10 +8023,16 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3tld___get__(struct __pyx_obj_3
  */
     __Pyx_TraceLine(319,0,__PYX_ERR(1, 319, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
-    __pyx_t_2 = __Pyx_decode_cpp_string(__pyx_v_3url_3url_psl.getTLD(__pyx_v_self->__pyx_base.ptr->host()), 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_2)) __PYX_ERR(1, 319, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_r = __pyx_t_2;
-    __pyx_t_2 = 0;
+    try {
+      __pyx_t_2 = __pyx_v_3url_3url_psl.getTLD(__pyx_v_self->__pyx_base.ptr->host());
+    } catch(...) {
+      __Pyx_CppExn2PyErr();
+      __PYX_ERR(1, 319, __pyx_L1_error)
+    }
+    __pyx_t_3 = __Pyx_decode_cpp_string(__pyx_t_2, 0, PY_SSIZE_T_MAX, NULL, NULL, PyUnicode_DecodeUTF8); if (unlikely(!__pyx_t_3)) __PYX_ERR(1, 319, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_3);
+    __pyx_r = __pyx_t_3;
+    __pyx_t_3 = 0;
     goto __pyx_L0;
 
     /* "url/url.pyx":318
@@ -8039,7 +8067,7 @@ static PyObject *__pyx_pf_3url_3url_10UnicodeURL_3tld___get__(struct __pyx_obj_3
 
   /* function exit code */
   __pyx_L1_error:;
-  __Pyx_XDECREF(__pyx_t_2);
+  __Pyx_XDECREF(__pyx_t_3);
   __Pyx_AddTraceback("url.url.UnicodeURL.tld.__get__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -9774,7 +9802,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {0, 0, 0, 0, 0, 0, 0}
 };
 static int __Pyx_InitCachedBuiltins(void) {
-  __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 22, __pyx_L1_error)
+  __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(0, 25, __pyx_L1_error)
   __pyx_builtin_NotImplementedError = __Pyx_GetBuiltinName(__pyx_n_s_NotImplementedError); if (!__pyx_builtin_NotImplementedError) __PYX_ERR(1, 111, __pyx_L1_error)
   return 0;
   __pyx_L1_error:;

--- a/url/url.pxd
+++ b/url/url.pxd
@@ -6,15 +6,18 @@ from libcpp.string cimport string
 from libcpp.unordered_set cimport unordered_set
 from libcpp cimport bool
 
+
 cdef extern from "url-cpp/include/psl.h" namespace "Url":
     cpdef cppclass PSL:
+        PSL()
+        PSL(const PSL& other)
         PSL& operator=(const PSL& other)
         @staticmethod
         PSL fromPath(const string& path)
         @staticmethod
-        PSL fromString(const string& str)
-        string getTLD(const string& hostname) const
-        string getPLD(const string& hostname) const
+        PSL fromString(const string& path)
+        string getTLD(const string& host) except +
+        string getPLD(const string& host) except +
 
 
 cdef extern from "url-cpp/include/url.h" namespace "Url":
@@ -61,16 +64,3 @@ cdef extern from "url-cpp/include/url.h" namespace "Url":
         Url& defrag()
         Url& punycode() except +ValueError
         Url& unpunycode() except +ValueError
-
-
-cdef extern from "url-cpp/include/psl.h" namespace "Url":
-    cpdef cppclass PSL:
-        PSL()
-        PSL(const PSL& other)
-        PSL& operator=(const PSL& other)
-        @staticmethod
-        PSL fromPath(const string& path)
-        @staticmethod
-        PSL fromString(const string& path)
-        string getTLD(const string& host) except +ValueError
-        string getPLD(const string& host) except +ValueError


### PR DESCRIPTION
I've combined the two separate definitions of PSL in url.pxd. Previously, there were two conflicting definitions. One did not specify the required exception handling, and this one appears to
have been taking affect since it was first.

I've also switched over to using `except +` instead of `except +ValueError`. This allows the C++ code to throw other types of exceptions besides invalid_argument and for them to be mapped
correctly.

This fixes #56.